### PR TITLE
Adding sphinx requirements.txt file for readthedocs

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,0 +1,3 @@
+
+breathe
+


### PR DESCRIPTION
Sphinx docs generated successfully on https://hipfft-saad.readthedocs.io/en/readthedocs/

Once merged, hipfft.readthedocs.io will be enabled.