### PR TITLE
Support CUDA-only builds

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -115,11 +115,20 @@ rocm_install_targets(TARGETS hipfft
 )
 
 # Export targets
-rocm_export_targets(TARGETS hip::hipfft
+
+if(NOT BUILD_WITH_LIB STREQUAL "CUDA")
+    rocm_export_targets(TARGETS hip::hipfft
                     PREFIX hipfft
                     DEPENDS PACKAGE hip
                     NAMESPACE hip::
-)
+    )
+else()
+	rocm_export_targets(TARGETS hip::hipfft
+                    PREFIX hipfft
+		    DEPENDS HIP MODULE
+                    NAMESPACE hip::
+        )
+endif()
 
 # Symbolic links
 rocm_install_symlink_subdir(hipfft)


### PR DESCRIPTION
hipFFT currently doesn't build on a system with only `HIP-CUDA` installed, since it uses the `hip` config package instead of the `HIP` module package (which was quite confusing when I ran into this issue)

This PR is a WIP attempt to fix the build issues as I go along integrating hipFFT into [Ginkgo](https://github.com/ginkgo-project/ginkgo)

The CUDA-specific code is right now shamelessly adapted from the corresponding hipBLAS code, but maybe there should be a more consistent way to deal with the ROCm/CUDA distinction.