### PR TITLE
Removed redundant and hard coded include path from install interface

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -71,6 +71,8 @@ if( BUILD_WITH_COMPILER STREQUAL "HOST-DEFAULT" )
 endif()
 
 # Target include directories
+# Hip header files installed in cmake install includedir
+# HIP_INCLUDE_DIRS is not required
 target_include_directories( hipfft
   PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/include>
   PUBLIC  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/library/include>
@@ -78,7 +80,6 @@ target_include_directories( hipfft
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
   $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  ${HIP_INCLUDE_DIRS}
   )
 
 if( BUILD_WITH_LIB STREQUAL "CUDA" )
@@ -135,7 +136,7 @@ if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
 endif( )
 
 if( ROCM_FOUND )
-  
+
   rocm_install_targets( TARGETS hipfft
     INCLUDE
     ${CMAKE_BINARY_DIR}/include


### PR DESCRIPTION
With file reorganization, hip header files are installed in /opt/rocm-ver/include/hip
Including CMAKE_INSTALL_INCLUDEDIR will help to find the hip header files.
Also the HIP_INCLUDE_DIRS is coming as hard coded path in config file and having hard coded paths in config files is not recommended

resolves #___

Summary of proposed changes:
-  
-  
-  
