### PR TITLE
HOTFIX: Remove backwards compatibility headers on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ include(cmake/dependencies.cmake)
 
 # FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG
 option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" ON)
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_wrap_header_dir(
     ${CMAKE_SOURCE_DIR}/library/include
     PATTERNS "*.h"

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -126,7 +126,7 @@ include( GenerateExportHeader )
 generate_export_header( hipfft EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/hipfft/hipfft-export.h )
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/library/include ${PROJECT_BINARY_DIR}/include/hipfft)
-if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_wrap_header_file(
     hipfft-version.h hipfft-export.h
     GUARDS SYMLINK WRAPPER
@@ -142,7 +142,7 @@ if( ROCM_FOUND )
     ${CMAKE_BINARY_DIR}/include
   )
 
-  if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+  if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
     rocm_install(
     DIRECTORY
        "${PROJECT_BINARY_DIR}/hipfft"


### PR DESCRIPTION
The backwards compatibility headers should not be generated or installed on Windows.