### PR TITLE
Use typedef names in api.rst for Doxygen

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -25,11 +25,11 @@ different library functions.
 
 .. doxygendefine:: HIPFFT_BACKWARD
 
-.. doxygenenum:: hipfftType_t
+.. doxygenenum:: hipfftType
 
 .. doxygentypedef:: hipfftHandle
 
-.. doxygenenum:: hipfftResult_t
+.. doxygenenum:: hipfftResult
 
 
 Simple plans
@@ -164,8 +164,8 @@ Execution is performed with the appropriate
 
 .. doxygenfunction:: hipfftXtSetGPUs
 
-.. doxygenstruct:: hipXtDesc_t
-.. doxygenstruct:: hipLibXtDesc_t
+.. doxygenstruct:: hipXtDesc
+.. doxygenstruct:: hipLibXtDesc
 
 .. doxygenfunction:: hipfftXtMalloc
 .. doxygenfunction:: hipfftXtFree


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
-  Use typedef names instead of struct/enum names in api.rst for Doxygen

Since Doxyfile declares `TYPEDEF_HIDES_STRUCT = YES` the documentation needs to use typedef names instead of struct/enum names. This fixes the warnings like
> doxygenenum: Cannot find enum “hipfftType_t” in doxygen xml output for project “hipFFT 1.0.14 Documentation” from directory: /home/docs/checkouts/readthedocs.org/user_builds/advanced-micro-devices-hipfft/checkouts/latest/docs/doxygen/xml

as visible with the current version of https://rocm.docs.amd.com/projects/hipFFT/en/latest/api.html.