### PR TITLE
cmake: copy hipfft-test third party DLLs to test output dir

### DIFF
--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -184,6 +184,6 @@ if (WIN32)
     C:/Windows/System32/libomp140*.dll
   )
   foreach( file_i ${third_party_dlls})
-    add_custom_command( TARGET hipfft-test POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy ${file_i} ${PROJECT_BINARY_DIR}/staging )
+    add_custom_command( TARGET hipfft-test POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy ${file_i} $<TARGET_FILE_DIR:hipfft-test> )
   endforeach( file_i )
 endif()


### PR DESCRIPTION
Cherry-pick for 6.3 release.