### PR TITLE
Resolve FFTW3 memory leak in simple_test

### DIFF
--- a/clients/tests/simple_test.cpp
+++ b/clients/tests/simple_test.cpp
@@ -560,6 +560,8 @@ TEST(hipfftTest, RunR2C)
     nrmse /= maxv;
 
     EXPECT_TRUE(nrmse < type_epsilon<double>());
+    fftw_destroy_plan(ref_p);
+    fftw_cleanup();
     fftw_free(ref_out);
 }
 
@@ -637,5 +639,7 @@ TEST(hipfftTest, OutplaceOnly)
     nrmse /= maxv;
 
     ASSERT_TRUE(nrmse < type_epsilon<double>());
+    fftw_destroy_plan(ref_p);
+    fftw_cleanup();
     fftw_free(ref_out);
 }


### PR DESCRIPTION
Summary of proposed changes:
-  Add calls to destroy fftw3 plan and perform fftw3 cleanup to prevent memory leaks