### PR TITLE
simplify library exception handling

### DIFF
--- a/library/src/amd_detail/hipfft.cpp
+++ b/library/src/amd_detail/hipfft.cpp
@@ -329,6 +329,20 @@ struct hipfft_plan_description_t
     }
 };
 
+static inline hipfftResult handle_exception() noexcept
+try
+{
+    throw;
+}
+catch(hipfftResult e)
+{
+    return e;
+}
+catch(...)
+{
+    return HIPFFT_INTERNAL_ERROR;
+}
+
 hipfftResult hipfftPlan1d(hipfftHandle* plan, int nx, hipfftType type, int batch)
 try
 {
@@ -338,13 +352,9 @@ try
 
     return hipfftMakePlan1d(*plan, nx, type, batch, nullptr);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftPlan2d(hipfftHandle* plan, int nx, int ny, hipfftType type)
@@ -357,13 +367,9 @@ try
 
     return hipfftMakePlan2d(*plan, nx, ny, type, nullptr);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftPlan3d(hipfftHandle* plan, int nx, int ny, int nz, hipfftType type)
@@ -376,13 +382,9 @@ try
 
     return hipfftMakePlan3d(*plan, nx, ny, nz, type, nullptr);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftPlanMany(hipfftHandle* plan,
@@ -405,13 +407,9 @@ try
     return hipfftMakePlanMany(
         *plan, rank, n, inembed, istride, idist, onembed, ostride, odist, type, batch, nullptr);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftPlanMany64(hipfftHandle*  plan,
@@ -434,13 +432,9 @@ try
     return hipfftMakePlanMany64(
         *plan, rank, n, inembed, istride, idist, onembed, ostride, odist, type, batch, nullptr);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftMakePlan_internal(hipfftHandle               plan,
@@ -948,13 +942,9 @@ try
     *plan = h;
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftExtPlanScaleFactor(hipfftHandle plan, double scalefactor)
@@ -965,13 +955,9 @@ try
     plan->scale_factor = scalefactor;
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult
@@ -994,13 +980,9 @@ try
     return hipfftMakePlan_internal(
         plan, 1, lengths, iotype, number_of_transforms, desc, workSize, false);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftMakePlan2d(hipfftHandle plan, int nx, int ny, hipfftType type, size_t* workSize)
@@ -1023,13 +1005,9 @@ try
     return hipfftMakePlan_internal(
         plan, 2, lengths, iotype, number_of_transforms, desc, workSize, false);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult
@@ -1054,13 +1032,9 @@ try
     return hipfftMakePlan_internal(
         plan, 3, lengths, iotype, number_of_transforms, desc, workSize, false);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 template <typename T>
@@ -1190,13 +1164,9 @@ try
     return hipfftMakePlanMany_internal<int>(
         plan, rank, n, inembed, istride, idist, onembed, ostride, odist, iotype, batch, workSize);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftMakePlanMany64(hipfftHandle   plan,
@@ -1219,13 +1189,9 @@ try
     return hipfftMakePlanMany_internal<long long int>(
         plan, rank, n, inembed, istride, idist, onembed, ostride, odist, iotype, batch, workSize);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftEstimate1d(int nx, hipfftType type, int batch, size_t* workSize)
@@ -1235,13 +1201,9 @@ try
     hipfftResult ret  = hipfftGetSize1d(plan, nx, type, batch, workSize);
     return ret;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftEstimate2d(int nx, int ny, hipfftType type, size_t* workSize)
@@ -1251,13 +1213,9 @@ try
     hipfftResult ret  = hipfftGetSize2d(plan, nx, ny, type, workSize);
     return ret;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftEstimate3d(int nx, int ny, int nz, hipfftType type, size_t* workSize)
@@ -1267,13 +1225,9 @@ try
     hipfftResult ret  = hipfftGetSize3d(plan, nx, ny, nz, type, workSize);
     return ret;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftEstimateMany(int        rank,
@@ -1294,13 +1248,9 @@ try
         plan, rank, n, inembed, istride, idist, onembed, ostride, odist, type, batch, workSize);
     return ret;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult
@@ -1319,13 +1269,9 @@ try
 
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftGetSize2d(hipfftHandle plan, int nx, int ny, hipfftType type, size_t* workSize)
@@ -1343,13 +1289,9 @@ try
 
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult
@@ -1368,13 +1310,9 @@ try
 
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftGetSizeMany(hipfftHandle plan,
@@ -1399,13 +1337,9 @@ try
 
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftGetSizeMany64(hipfftHandle   plan,
@@ -1430,13 +1364,9 @@ try
 
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftGetSize(hipfftHandle plan, size_t* workSize)
@@ -1445,13 +1375,9 @@ try
     *workSize = plan->workBufferSize;
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftSetAutoAllocation(hipfftHandle plan, int autoAllocate)
@@ -1461,13 +1387,9 @@ try
         plan->autoAllocate = bool(autoAllocate);
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftSetWorkArea(hipfftHandle plan, void* workArea)
@@ -1486,13 +1408,9 @@ try
     }
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 // Find the specific plan to execute - check placement and direction
@@ -1550,13 +1468,9 @@ try
     }
     return HIPFFT_EXEC_FAILED;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftExecR2C(hipfftHandle plan, hipfftReal* idata, hipfftComplex* odata)
@@ -1564,13 +1478,9 @@ try
 {
     return hipfftExecForward(plan, idata, odata);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftExecC2R(hipfftHandle plan, hipfftComplex* idata, hipfftReal* odata)
@@ -1578,13 +1488,9 @@ try
 {
     return hipfftExecBackward(plan, idata, odata);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftExecZ2Z(hipfftHandle         plan,
@@ -1602,13 +1508,9 @@ try
     }
     return HIPFFT_EXEC_FAILED;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftExecD2Z(hipfftHandle plan, hipfftDoubleReal* idata, hipfftDoubleComplex* odata)
@@ -1616,13 +1518,9 @@ try
 {
     return hipfftExecForward(plan, idata, odata);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftExecZ2D(hipfftHandle plan, hipfftDoubleComplex* idata, hipfftDoubleReal* odata)
@@ -1630,13 +1528,9 @@ try
 {
     return hipfftExecBackward(plan, idata, odata);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftSetStream(hipfftHandle plan, hipStream_t stream)
@@ -1645,13 +1539,9 @@ try
     ROC_FFT_CHECK_INVALID_VALUE(rocfft_execution_info_set_stream(plan->info, stream));
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftDestroy(hipfftHandle plan)
@@ -1681,13 +1571,9 @@ try
 
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftGetVersion(int* version)
@@ -1718,13 +1604,9 @@ try
     *version = std::stoi(result.str());
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftGetProperty(hipfftLibraryPropertyType type, int* value)
@@ -1748,13 +1630,9 @@ try
 
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtSetCallback(hipfftHandle         plan,
@@ -1848,13 +1726,9 @@ try
         return HIPFFT_INVALID_VALUE;
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtClearCallback(hipfftHandle plan, hipfftXtCallbackType cbtype)
@@ -1862,13 +1736,9 @@ try
 {
     return hipfftXtSetCallback(plan, nullptr, cbtype, nullptr);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult
@@ -1911,13 +1781,9 @@ try
         return HIPFFT_INVALID_VALUE;
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtMakePlanMany(hipfftHandle   plan,
@@ -1941,13 +1807,9 @@ try
     return hipfftMakePlanMany_internal<long long int>(
         plan, rank, n, inembed, istride, idist, onembed, ostride, odist, iotype, batch, workSize);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtGetSizeMany(hipfftHandle   plan,
@@ -1977,13 +1839,9 @@ try
     HIP_FFT_CHECK_AND_RETURN(hipfftDestroy(p));
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExec(hipfftHandle plan, void* input, void* output, int direction)
@@ -2004,13 +1862,9 @@ try
 
     return hipfftExec(plan_ptr, plan->info, input, output);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtSetGPUs(hipfftHandle plan, int count, int* gpus)
@@ -2037,13 +1891,9 @@ try
 
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 // get number of bytes used for elements of a given hipDataType
@@ -2133,13 +1983,9 @@ try
     *desc                = lib_desc.release();
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_ALLOC_FAILED;
+    return handle_exception();
 }
 
 // collapse contiguous dimensions in the specified length + stride -
@@ -2325,13 +2171,9 @@ try
         throw HIPFFT_INVALID_VALUE;
     }
 }
-catch(hipfftResult err)
-{
-    return err;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtFree(hipLibXtDesc* desc)
@@ -2349,13 +2191,9 @@ try
     delete desc;
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 static hipfftResult hipfftXtExecDescriptorBase(const rocfft_plan&           rplan,
@@ -2387,13 +2225,9 @@ try
 
     return hipfftXtExecDescriptorBase(rplan, plan->info, input, output);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExecDescriptorR2C(hipfftHandle plan, hipLibXtDesc* input, hipLibXtDesc* output)
@@ -2407,13 +2241,9 @@ try
 
     return hipfftXtExecDescriptorBase(rplan, plan->info, input, output);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExecDescriptorC2R(hipfftHandle plan, hipLibXtDesc* input, hipLibXtDesc* output)
@@ -2427,13 +2257,9 @@ try
 
     return hipfftXtExecDescriptorBase(rplan, plan->info, input, output);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExecDescriptorZ2Z(hipfftHandle  plan,
@@ -2450,13 +2276,9 @@ try
 
     return hipfftXtExecDescriptorBase(rplan, plan->info, input, output);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExecDescriptorD2Z(hipfftHandle plan, hipLibXtDesc* input, hipLibXtDesc* output)
@@ -2470,13 +2292,9 @@ try
 
     return hipfftXtExecDescriptorBase(rplan, plan->info, input, output);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExecDescriptorZ2D(hipfftHandle plan, hipLibXtDesc* input, hipLibXtDesc* output)
@@ -2490,13 +2308,9 @@ try
 
     return hipfftXtExecDescriptorBase(rplan, plan->info, input, output);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExecDescriptor(hipfftHandle  plan,
@@ -2513,13 +2327,9 @@ try
 
     return hipfftXtExecDescriptorBase(rplan, plan->info, input, output);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 #ifdef HIPFFT_MPI_ENABLE
@@ -2546,13 +2356,9 @@ try
     plan->comm_handle = comm_handle;
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtSetDistribution(hipfftHandle         plan,
@@ -2606,13 +2412,9 @@ try
     setBrick(plan->outBricks.front(), output_lower, output_upper, output_stride);
     return HIPFFT_SUCCESS;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtSetSubformatDefault(hipfftHandle      plan,
@@ -2626,13 +2428,9 @@ try
 
     return HIPFFT_NOT_IMPLEMENTED;
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 #endif

--- a/library/src/nvidia_detail/hipfft.cpp
+++ b/library/src/nvidia_detail/hipfft.cpp
@@ -243,10 +243,10 @@ static cufftXtCopyType hipfftXtCopyTypeTocufftXtCopyType(hipfftXtCopyType t)
     }
 }
 
-hipfftResult hipfftPlan1d(hipfftHandle* plan, int nx, hipfftType type, int batch)
+static inline hipfftResult handle_exception() noexcept
 try
 {
-    return cufftResultToHipResult(cufftPlan1d(plan, nx, hipfftTypeToCufftType(type), batch));
+    throw;
 }
 catch(hipfftResult e)
 {
@@ -255,6 +255,16 @@ catch(hipfftResult e)
 catch(...)
 {
     return HIPFFT_INTERNAL_ERROR;
+}
+
+hipfftResult hipfftPlan1d(hipfftHandle* plan, int nx, hipfftType type, int batch)
+try
+{
+    return cufftResultToHipResult(cufftPlan1d(plan, nx, hipfftTypeToCufftType(type), batch));
+}
+catch(...)
+{
+    return handle_exception();
 }
 
 hipfftResult hipfftPlan2d(hipfftHandle* plan, int nx, int ny, hipfftType type)
@@ -262,13 +272,9 @@ try
 {
     return cufftResultToHipResult(cufftPlan2d(plan, nx, ny, hipfftTypeToCufftType(type)));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftPlan3d(hipfftHandle* plan, int nx, int ny, int nz, hipfftType type)
@@ -276,13 +282,9 @@ try
 {
     return cufftResultToHipResult(cufftPlan3d(plan, nx, ny, nz, hipfftTypeToCufftType(type)));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftPlanMany(hipfftHandle* plan,
@@ -319,13 +321,9 @@ try
         return cufftResultToHipResult(cufftret);
     }
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 /*===========================================================================*/
@@ -335,13 +333,9 @@ try
 {
     return cufftResultToHipResult(cufftCreate(plan));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftExtPlanScaleFactor(hipfftHandle plan, double scalefactor)
@@ -356,13 +350,9 @@ try
     return cufftResultToHipResult(
         cufftMakePlan1d(plan, nx, hipfftTypeToCufftType(type), batch, workSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftMakePlan2d(hipfftHandle plan, int nx, int ny, hipfftType type, size_t* workSize)
@@ -371,13 +361,9 @@ try
     return cufftResultToHipResult(
         cufftMakePlan2d(plan, nx, ny, hipfftTypeToCufftType(type), workSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult
@@ -387,13 +373,9 @@ try
     return cufftResultToHipResult(
         cufftMakePlan3d(plan, nx, ny, nz, hipfftTypeToCufftType(type), workSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftMakePlanMany(hipfftHandle plan,
@@ -428,13 +410,9 @@ try
                                  workSize);
     return cufftResultToHipResult(cufftret);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftMakePlanMany64(hipfftHandle   plan,
@@ -464,13 +442,9 @@ try
                                                       batch,
                                                       workSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 /*===========================================================================*/
@@ -481,13 +455,9 @@ try
     return cufftResultToHipResult(
         cufftEstimate1d(nx, hipfftTypeToCufftType(type), batch, workSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftEstimate2d(int nx, int ny, hipfftType type, size_t* workSize)
@@ -495,13 +465,9 @@ try
 {
     return cufftResultToHipResult(cufftEstimate2d(nx, ny, hipfftTypeToCufftType(type), workSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftEstimate3d(int nx, int ny, int nz, hipfftType type, size_t* workSize)
@@ -510,13 +476,9 @@ try
     return cufftResultToHipResult(
         cufftEstimate3d(nx, ny, nz, hipfftTypeToCufftType(type), workSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftEstimateMany(int        rank,
@@ -544,13 +506,9 @@ try
                                                     batch,
                                                     workSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 /*===========================================================================*/
@@ -562,13 +520,9 @@ try
     return cufftResultToHipResult(
         cufftGetSize1d(plan, nx, hipfftTypeToCufftType(type), batch, workSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftGetSize2d(hipfftHandle plan, int nx, int ny, hipfftType type, size_t* workSize)
@@ -577,13 +531,9 @@ try
     return cufftResultToHipResult(
         cufftGetSize2d(plan, nx, ny, hipfftTypeToCufftType(type), workSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult
@@ -593,13 +543,9 @@ try
     return cufftResultToHipResult(
         cufftGetSize3d(plan, nx, ny, nz, hipfftTypeToCufftType(type), workSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftGetSizeMany(hipfftHandle plan,
@@ -629,13 +575,9 @@ try
                                                    batch,
                                                    workSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftGetSizeMany64(hipfftHandle   plan,
@@ -665,13 +607,9 @@ try
                                                      batch,
                                                      workSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftGetSize(hipfftHandle plan, size_t* workSize)
@@ -679,13 +617,9 @@ try
 {
     return cufftResultToHipResult(cufftGetSize(plan, workSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 /*===========================================================================*/
@@ -695,13 +629,9 @@ try
 {
     return cufftResultToHipResult(cufftSetAutoAllocation(plan, autoAllocate));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftSetWorkArea(hipfftHandle plan, void* workArea)
@@ -709,13 +639,9 @@ try
 {
     return cufftResultToHipResult(cufftSetWorkArea(plan, workArea));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 /*===========================================================================*/
@@ -726,13 +652,9 @@ try
 {
     return cufftResultToHipResult(cufftExecC2C(plan, idata, odata, direction));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftExecR2C(hipfftHandle plan, hipfftReal* idata, hipfftComplex* odata)
@@ -740,13 +662,9 @@ try
 {
     return cufftResultToHipResult(cufftExecR2C(plan, idata, odata));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftExecC2R(hipfftHandle plan, hipfftComplex* idata, hipfftReal* odata)
@@ -754,13 +672,9 @@ try
 {
     return cufftResultToHipResult(cufftExecC2R(plan, idata, odata));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftExecZ2Z(hipfftHandle         plan,
@@ -771,13 +685,9 @@ try
 {
     return cufftResultToHipResult(cufftExecZ2Z(plan, idata, odata, direction));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftExecD2Z(hipfftHandle plan, hipfftDoubleReal* idata, hipfftDoubleComplex* odata)
@@ -785,13 +695,9 @@ try
 {
     return cufftResultToHipResult(cufftExecD2Z(plan, idata, odata));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftExecZ2D(hipfftHandle plan, hipfftDoubleComplex* idata, hipfftDoubleReal* odata)
@@ -799,13 +705,9 @@ try
 {
     return cufftResultToHipResult(cufftExecZ2D(plan, idata, odata));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 /*===========================================================================*/
@@ -815,13 +717,9 @@ try
 {
     return cufftResultToHipResult(cufftSetStream(plan, stream));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftDestroy(hipfftHandle plan)
@@ -829,13 +727,9 @@ try
 {
     return cufftResultToHipResult(cufftDestroy(plan));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftGetVersion(int* version)
@@ -843,13 +737,9 @@ try
 {
     return cufftResultToHipResult(cufftGetVersion(version));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftGetProperty(hipfftLibraryPropertyType type, int* value)
@@ -858,13 +748,9 @@ try
     return cufftResultToHipResult(
         cufftGetProperty(hipfftLibraryPropertyTypeToCufftLibraryPropertyType(type), value));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtSetCallback(hipfftHandle         plan,
@@ -876,13 +762,9 @@ try
     return cufftResultToHipResult(cufftXtSetCallback(
         plan, callbacks, hipfftCallbackTypeToCufftCallbackType(cbtype), callbackData));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtClearCallback(hipfftHandle plan, hipfftXtCallbackType cbtype)
@@ -891,13 +773,9 @@ try
     return cufftResultToHipResult(
         cufftXtClearCallback(plan, hipfftCallbackTypeToCufftCallbackType(cbtype)));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult
@@ -907,13 +785,9 @@ try
     return cufftResultToHipResult(cufftXtSetCallbackSharedSize(
         plan, hipfftCallbackTypeToCufftCallbackType(cbtype), sharedSize));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtMakePlanMany(hipfftHandle   plan,
@@ -947,13 +821,9 @@ try
                                                       workSize,
                                                       executiontype));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtGetSizeMany(hipfftHandle   plan,
@@ -987,13 +857,9 @@ try
                                                      workSize,
                                                      executiontype));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExec(hipfftHandle plan, void* input, void* output, int direction)
@@ -1001,13 +867,9 @@ try
 {
     return cufftResultToHipResult(cufftXtExec(plan, input, output, direction));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtSetGPUs(hipfftHandle plan, int count, int* gpus)
@@ -1015,13 +877,9 @@ try
 {
     return cufftResultToHipResult(cufftXtSetGPUs(plan, count, gpus));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtMalloc(hipfftHandle plan, hipLibXtDesc** desc, hipfftXtSubFormat format)
@@ -1031,13 +889,9 @@ try
         plan, reinterpret_cast<cudaLibXtDesc**>(desc), hipfftXtSubFormatTocufftXtSubFormat(format));
     return cufftResultToHipResult(cufftret);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtMemcpy(hipfftHandle plan, void* dest, void* src, hipfftXtCopyType type)
@@ -1046,13 +900,9 @@ try
     auto cufftret = cufftXtMemcpy(plan, dest, src, hipfftXtCopyTypeTocufftXtCopyType(type));
     return cufftResultToHipResult(cufftret);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtFree(hipLibXtDesc* desc)
@@ -1061,13 +911,9 @@ try
     auto cufftret = cufftXtFree(reinterpret_cast<cudaLibXtDesc*>(desc));
     return cufftResultToHipResult(cufftret);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExecDescriptorC2C(hipfftHandle  plan,
@@ -1082,13 +928,9 @@ try
                                              direction);
     return cufftResultToHipResult(cufftret);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExecDescriptorR2C(hipfftHandle plan, hipLibXtDesc* input, hipLibXtDesc* output)
@@ -1098,13 +940,9 @@ try
         plan, reinterpret_cast<cudaLibXtDesc*>(input), reinterpret_cast<cudaLibXtDesc*>(output));
     return cufftResultToHipResult(cufftret);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExecDescriptorC2R(hipfftHandle plan, hipLibXtDesc* input, hipLibXtDesc* output)
@@ -1114,13 +952,9 @@ try
         plan, reinterpret_cast<cudaLibXtDesc*>(input), reinterpret_cast<cudaLibXtDesc*>(output));
     return cufftResultToHipResult(cufftret);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExecDescriptorZ2Z(hipfftHandle  plan,
@@ -1135,13 +969,9 @@ try
                                              direction);
     return cufftResultToHipResult(cufftret);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExecDescriptorD2Z(hipfftHandle plan, hipLibXtDesc* input, hipLibXtDesc* output)
@@ -1151,13 +981,9 @@ try
         plan, reinterpret_cast<cudaLibXtDesc*>(input), reinterpret_cast<cudaLibXtDesc*>(output));
     return cufftResultToHipResult(cufftret);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExecDescriptorZ2D(hipfftHandle plan, hipLibXtDesc* input, hipLibXtDesc* output)
@@ -1167,13 +993,9 @@ try
         plan, reinterpret_cast<cudaLibXtDesc*>(input), reinterpret_cast<cudaLibXtDesc*>(output));
     return cufftResultToHipResult(cufftret);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtExecDescriptor(hipfftHandle  plan,
@@ -1188,13 +1010,9 @@ try
                                           direction);
     return cufftResultToHipResult(cufftret);
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 #ifdef HIPFFT_MPI_ENABLE
@@ -1216,13 +1034,9 @@ try
     auto cuComm = hipfftMpCommTypeToCufftMpCommType(comm_type);
     return cufftResultToHipResult(cufftMpAttachComm(plan, cuComm, comm_handle));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtSetDistribution(hipfftHandle         plan,
@@ -1244,13 +1058,9 @@ try
                                                          stride_input,
                                                          stride_output));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 hipfftResult hipfftXtSetSubformatDefault(hipfftHandle      plan,
@@ -1263,13 +1073,9 @@ try
                                    hipfftXtSubFormatTocufftXtSubFormat(subformat_forward),
                                    hipfftXtSubFormatTocufftXtSubFormat(subformat_inverse)));
 }
-catch(hipfftResult e)
-{
-    return e;
-}
 catch(...)
 {
-    return HIPFFT_INTERNAL_ERROR;
+    return handle_exception();
 }
 
 #endif


### PR DESCRIPTION
This PR simplifies exception handling in hipFFT API functions. The error handling function is implemented as:

```cpp
static inline hipfftResult handle_exception() noexcept
try
{
    throw;
}
catch(hipfftResult e)
{
    return e;
}
catch(...)
{
    return HIPFFT_INTERNAL_ERROR;
}
```
and each function definition can be simplified from:
```cpp
extern "C" hipfftResult api_call(...)
try
{
    // do stuff
    return HIPFFT_SUCCESS;
}
catch(hipfftResult e)
{
    return e;
}
catch(...)
{
    return HIPFFT_INTERNAL_ERROR;
}
```
to:
```cpp
extern "C" hipfftResult api_call(...)
try
{
    // do stuff
    return HIPFFT_SUCCESS;
}
catch(...)
{
    return handle_exception();
}
```