### PR TITLE
Add docs updates to docs/6.3.1

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -137,6 +137,40 @@ For complex-to-real transforms, the output buffer XXX
 .. doxygenfunction:: hipfftXtExec
 		     
 
+HIP graph support for hipFFT
+============================
+
+hipFFT supports capturing kernels launched during FFT execution into
+HIP graph nodes.  This way, users can capture FFT execution, along
+with other work, into a HIP graph and launch the work in the graph
+multiple times.
+
+The following hipFFT APIs can be used with graph capture:
+
+* :cpp:func:`hipfftExecC2C`
+
+* :cpp:func:`hipfftExecR2C`
+
+* :cpp:func:`hipfftExecC2R`
+
+* :cpp:func:`hipfftExecZ2Z`
+
+* :cpp:func:`hipfftExecD2Z`
+
+* :cpp:func:`hipfftExecZ2D`
+
+Note that each launch of a HIP graph will provide the same arguments
+to the kernels in the graph.  In particular, this implies that all of
+the parameters to the above APIs remain valid while the HIP graph is
+in use:
+
+* The hipFFT plan
+
+* The input and output buffers
+
+hipFFT does not support capturing work performed by other API
+functions aside from those listed above.
+
 Callbacks
 =========
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -136,6 +136,7 @@ For complex-to-real transforms, the output buffer XXX
 
 .. doxygenfunction:: hipfftXtExec
 		     
+.. _hip-graph-support-for-hipfft:
 
 HIP graph support for hipFFT
 ============================


### PR DESCRIPTION
Manually adding to docs/6.3.1 because 
the changes were not added to the release branch.

Commits in https://github.com/ROCm/hipFFT/pull/121
