### PR TITLE
Deprecate AMDGPU_TARGETS variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,8 @@ else()
   # Define GPU targets
   set(AMDGPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING "Target default GPUs if AMDGPU_TARGETS is not defined.")
   #rocm_check_target_ids(AMDGPU_TARGETS TARGETS "${AMDGPU_TARGETS}")
+  # Don't force as users should be able to override GPU_TARGETS at the command line if desired
+  set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for.")
   if( BUILD_WITH_COMPILER STREQUAL "HIP-CLANG" )
     set( HIP_PLATFORM "amd" )
     set( HIP_COMPILER "clang" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,10 +165,13 @@ if (BUILD_WITH_COMPILER STREQUAL "HIP-NVCC" )
 
 else()
   # Define GPU targets
-  set(AMDGPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING "Target default GPUs if AMDGPU_TARGETS is not defined.")
-  #rocm_check_target_ids(AMDGPU_TARGETS TARGETS "${AMDGPU_TARGETS}")
-  # Don't force as users should be able to override GPU_TARGETS at the command line if desired
-  set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for.")
+  if(AMDGPU_TARGETS AND NOT GPU_TARGETS)
+    message( DEPRECATION "AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS." )
+  endif()
+  set(AMDGPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING "Target default GPUs if AMDGPU_TARGETS is not defined. (Deprecated, prefer GPU_TARGETS)")
+  rocm_check_target_ids(AMDGPU_TARGETS TARGETS "${AMDGPU_TARGETS}")
+  # Don't force, users should be able to override GPU_TARGETS at the command line if desired
+  set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for")
   if( BUILD_WITH_COMPILER STREQUAL "HIP-CLANG" )
     set( HIP_PLATFORM "amd" )
     set( HIP_COMPILER "clang" )


### PR DESCRIPTION
Summary of proposed changes:

Change the CMake to set the GPU_TARGETS variable from AMDGPU_TARGETS if not set by the user
Change all usages of AMDGPU_TARGETS to GPU_TARGETS
