### PR TITLE
Codecov

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,3 +303,11 @@ if( ROCmCMakeBuildTools_FOUND )
     LDCONFIG_DIR ${HIPFFT_CONFIG_DIR}
     )
 endif()
+
+option(BUILD_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
+if (BUILD_CODE_COVERAGE)
+	set(COVERAGE_COMPILE_FLAGS "-g -O0 -fprofile-instr-generate -fcoverage-mapping ")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-instr-generate")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,11 +303,3 @@ if( ROCmCMakeBuildTools_FOUND )
     LDCONFIG_DIR ${HIPFFT_CONFIG_DIR}
     )
 endif()
-
-option(BUILD_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
-if (BUILD_CODE_COVERAGE)
-	set(COVERAGE_COMPILE_FLAGS "-g -O0 -fprofile-instr-generate -fcoverage-mapping ")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-instr-generate")
-endif()

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Here are some CMake build examples:
 The `-DBUILD_CLIENTS=ON` option is only allowed with the amdclang++ or HIPCC compilers.
 ```
 
+## Code Coverage
 You can generate a test coverage report with the following:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Here are some CMake build examples:
 The `-DBUILD_CLIENTS=ON` option is only allowed with the amdclang++ or HIPCC compilers.
 ```
 
+You can generate a test coverage report with the following:
+
+```bash
+cmake -DCMAKE_CXX_COMPILER=amdclang++ -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CODE_COVERAGE=ON <optional: -DCOVERAGE_TEST_OPTIONS="cmdline args to pass to hipfft-test (default: --smoketest)"> ..
+make -j coverage
+```
+The above will output the coverage report to the terminal and also save an html coverage report to `$PWD/coverage-report`.  Please note that we use llvm for code coverage, which only works with clang compilers.
+
 ## Porting from CUDA
 
 If you have existing CUDA code and want to transition to HIP, follow these steps:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can generate a test coverage report with the following:
 cmake -DCMAKE_CXX_COMPILER=amdclang++ -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CODE_COVERAGE=ON <optional: -DCOVERAGE_TEST_OPTIONS="cmdline args to pass to hipfft-test (default: --smoketest)"> ..
 make -j coverage
 ```
-The above will output the coverage report to the terminal and also save an html coverage report to `$PWD/coverage-report`.  Please note that we use llvm for code coverage, which only works with clang compilers.
+The commands above will output the coverage report to the terminal and save an html coverage report to `$PWD/coverage-report`.  Note that hipFFT uses llvm for code coverage, which only works with clang compilers.
 
 ## Porting from CUDA
 

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -238,24 +238,29 @@ if (BUILD_CODE_COVERAGE)
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 
+  find_program(
+    LLVM_PROFDATA
+    llvm-profdata
+    REQUIRED
+    HINTS ${ROCM_PATH}/llvm/bin
+    PATHS /opt/rocm/llvm/bin
+  )
+
+  find_program(
+    LLVM_COV
+    llvm-cov
+    REQUIRED
+    HINTS ${ROCM_PATH}/llvm/bin
+    PATHS /opt/rocm/llvm/bin
+  )
+
   add_custom_target(
     coverage
+    DEPENDS code_cov_tests
+    COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/hipfft-coverage_*.profraw -o ./coverage-report/hipfft.profdata
+    COMMAND ${LLVM_COV} report -object ./library/src/hipfft.so -instr-profile=./coverage-report/hipfft.profdata
+    COMMAND ${LLVM_COV} show -object ./library/src/hipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
     COMMAND /opt/rocm/llvm/bin/llvm-profdata merge -sparse ./coverage-report/profraw/hipfft-coverage_*.profraw -o ./coverage-report/hipfft.profdata
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
-
-  add_dependencies(coverage code_cov_tests)
-
-  add_custom_command(
-    TARGET coverage
-    COMMAND /opt/rocm/llvm/bin/llvm-cov report -object ./library/src/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  )
-
-  add_custom_command(
-    TARGET coverage
-    COMMAND /opt/rocm/llvm/bin/llvm-cov show -object ./library/src/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  )
-
 endif()

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -225,10 +225,9 @@ endif()
 
 option(BUILD_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
 if (BUILD_CODE_COVERAGE)
-        set(COVERAGE_COMPILE_FLAGS "-g -O0 -fprofile-instr-generate -fcoverage-mapping ")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-instr-generate")
+        set(COVERAGE_COMPILE_FLAGS -g -O0 -fprofile-instr-generate -fcoverage-mapping )
+	target_compile_options( hipfft-test PRIVATE ${COVERAGE_COMPILE_FLAGS} )
+	target_link_options( hipfft-test INTERFACE -fprofile-instr-generate )
 
 	add_custom_target(
 		code_cov_tests

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -226,9 +226,6 @@ endif()
 option(BUILD_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
 set(COVERAGE_TEST_OPTIONS "--smoketest" CACHE STRING "Command line arguments for hipfft-test when generating a code coverage report")
 if (BUILD_CODE_COVERAGE)
-  target_compile_options( hipfft PRIVATE -g -O0 -fprofile-instr-generate -fcoverage-mapping )
-  target_link_options( hipfft INTERFACE -fprofile-instr-generate )
-
   add_custom_target(
     code_cov_tests
     DEPENDS hipfft-test

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -255,8 +255,8 @@ if (BUILD_CODE_COVERAGE)
     coverage
     DEPENDS code_cov_tests
     COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/hipfft-coverage_*.profraw -o ./coverage-report/hipfft.profdata
-    COMMAND ${LLVM_COV} report -object ./library/hipfft.so -instr-profile=./coverage-report/hipfft.profdata
-    COMMAND ${LLVM_COV} show -object ./library/hipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
+    COMMAND ${LLVM_COV} report -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata
+    COMMAND ${LLVM_COV} show -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 endif()

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -231,8 +231,10 @@ if (BUILD_CODE_COVERAGE)
 
 	add_custom_target(
 		code_cov_tests
-		COMMAND echo Coverage GTEST_FILTER=\${GTEST_FILTER}
-		COMMAND mkdir -p ./coverage-report/profraw/ && rm -rf ./coverage-report/profraw/* && LLVM_PROFILE_FILE="./coverage-report/profraw/hipfft-coverage_%p.profraw" GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./clients/staging/hipfft-test --precompile=./clients/staging/hipfft-test-precompile.db  --gtest_color=yes --gtest_filter=\"\${GTEST_FILTER}\"
+		DEPENDS hipfft-test
+		COMMAND ${CMAKE_COMMAND} -E rm -rf ./coverage-report
+		COMMAND ${CMAKE_COMMAND} -E make_directory ./coverage-report/profraw
+		COMMAND ${CMAKE_COMMAND} -E env LLVM_PROFILE_FILE="./coverage-report/profraw/hipfft-coverage_%p.profraw" GTEST_LISTENER=NO_PASS_LINE_IN_LOG $<TARGET_FILE:hipfft-test> --precompile=./clients/staging/hipfft-test-precompile.db ${COVERAGE_TEST_OPTIONS}
 		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 	)
 

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -226,8 +226,8 @@ endif()
 option(BUILD_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
 set(COVERAGE_TEST_OPTIONS "--smoketest" CACHE STRING "Command line arguments for hipfft-test when generating a code coverage report")
 if (BUILD_CODE_COVERAGE)
-  target_compile_options( hipfft-test PRIVATE -g -O0 -fprofile-instr-generate -fcoverage-mapping )
-  target_link_options( hipfft-test INTERFACE -fprofile-instr-generate )
+  target_compile_options( hipfft PRIVATE -g -O0 -fprofile-instr-generate -fcoverage-mapping )
+  target_link_options( hipfft INTERFACE -fprofile-instr-generate )
 
   add_custom_target(
     code_cov_tests

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -225,37 +225,37 @@ endif()
 
 option(BUILD_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
 if (BUILD_CODE_COVERAGE)
-        set(COVERAGE_COMPILE_FLAGS -g -O0 -fprofile-instr-generate -fcoverage-mapping )
-	target_compile_options( hipfft-test PRIVATE ${COVERAGE_COMPILE_FLAGS} )
-	target_link_options( hipfft-test INTERFACE -fprofile-instr-generate )
+  set(COVERAGE_COMPILE_FLAGS -g -O0 -fprofile-instr-generate -fcoverage-mapping )
+  target_compile_options( hipfft-test PRIVATE ${COVERAGE_COMPILE_FLAGS} )
+  target_link_options( hipfft-test INTERFACE -fprofile-instr-generate )
 
-	add_custom_target(
-		code_cov_tests
-		DEPENDS hipfft-test
-		COMMAND ${CMAKE_COMMAND} -E rm -rf ./coverage-report
-		COMMAND ${CMAKE_COMMAND} -E make_directory ./coverage-report/profraw
-		COMMAND ${CMAKE_COMMAND} -E env LLVM_PROFILE_FILE="./coverage-report/profraw/hipfft-coverage_%p.profraw" GTEST_LISTENER=NO_PASS_LINE_IN_LOG $<TARGET_FILE:hipfft-test> --precompile=./clients/staging/hipfft-test-precompile.db ${COVERAGE_TEST_OPTIONS}
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-	)
+  add_custom_target(
+    code_cov_tests
+    DEPENDS hipfft-test
+    COMMAND ${CMAKE_COMMAND} -E rm -rf ./coverage-report
+    COMMAND ${CMAKE_COMMAND} -E make_directory ./coverage-report/profraw
+    COMMAND ${CMAKE_COMMAND} -E env LLVM_PROFILE_FILE="./coverage-report/profraw/hipfft-coverage_%p.profraw" GTEST_LISTENER=NO_PASS_LINE_IN_LOG $<TARGET_FILE:hipfft-test> --precompile=./clients/staging/hipfft-test-precompile.db ${COVERAGE_TEST_OPTIONS}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
 
-	add_custom_target(
-		coverage
-		COMMAND /opt/rocm/llvm/bin/llvm-profdata merge -sparse ./coverage-report/profraw/hipfft-coverage_*.profraw -o ./coverage-report/hipfft.profdata
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-	)
+  add_custom_target(
+    coverage
+    COMMAND /opt/rocm/llvm/bin/llvm-profdata merge -sparse ./coverage-report/profraw/hipfft-coverage_*.profraw -o ./coverage-report/hipfft.profdata
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
 
-	add_dependencies(coverage code_cov_tests)
+  add_dependencies(coverage code_cov_tests)
 
-	add_custom_command(
-		TARGET coverage
-		COMMAND /opt/rocm/llvm/bin/llvm-cov report -object ./library/src/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-	)
+  add_custom_command(
+    TARGET coverage
+    COMMAND /opt/rocm/llvm/bin/llvm-cov report -object ./library/src/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
 
-	add_custom_command(
-		TARGET coverage
-		COMMAND /opt/rocm/llvm/bin/llvm-cov show -object ./library/src/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-	)
+  add_custom_command(
+    TARGET coverage
+    COMMAND /opt/rocm/llvm/bin/llvm-cov show -object ./library/src/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
 
 endif()

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -222,3 +222,39 @@ if (WIN32)
     add_custom_command( TARGET hipfft-test POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy ${file_i} $<TARGET_FILE_DIR:hipfft-test> )
   endforeach( file_i )
 endif()
+
+option(BUILD_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
+if (BUILD_CODE_COVERAGE)
+        set(COVERAGE_COMPILE_FLAGS "-g -O0 -fprofile-instr-generate -fcoverage-mapping ")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-instr-generate")
+
+	add_custom_target(
+		code_cov_tests
+		COMMAND echo Coverage GTEST_FILTER=\${GTEST_FILTER}
+		COMMAND mkdir -p ./coverage-report/profraw/ && rm -rf ./coverage-report/profraw/* && LLVM_PROFILE_FILE="./coverage-report/profraw/hipfft-coverage_%p.profraw" GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./clients/staging/hipfft-test --precompile=./clients/staging/hipfft-test-precompile.db  --gtest_color=yes --gtest_filter=\"\${GTEST_FILTER}\"
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+	)
+
+	add_custom_target(
+		coverage
+		COMMAND /opt/rocm/llvm/bin/llvm-profdata merge -sparse ./coverage-report/profraw/hipfft-coverage_*.profraw -o ./coverage-report/hipfft.profdata
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+	)
+
+	add_dependencies(coverage code_cov_tests)
+
+	add_custom_command(
+		TARGET coverage
+		COMMAND /opt/rocm/llvm/bin/llvm-cov report -object ./library/src/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+	)
+
+	add_custom_command(
+		TARGET coverage
+		COMMAND /opt/rocm/llvm/bin/llvm-cov show -object ./library/src/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+	)
+
+endif()

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -258,9 +258,8 @@ if (BUILD_CODE_COVERAGE)
     coverage
     DEPENDS code_cov_tests
     COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/hipfft-coverage_*.profraw -o ./coverage-report/hipfft.profdata
-    COMMAND ${LLVM_COV} report -object ./library/src/hipfft.so -instr-profile=./coverage-report/hipfft.profdata
-    COMMAND ${LLVM_COV} show -object ./library/src/hipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
-    COMMAND /opt/rocm/llvm/bin/llvm-profdata merge -sparse ./coverage-report/profraw/hipfft-coverage_*.profraw -o ./coverage-report/hipfft.profdata
+    COMMAND ${LLVM_COV} report -object ./library/hipfft.so -instr-profile=./coverage-report/hipfft.profdata
+    COMMAND ${LLVM_COV} show -object ./library/hipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 endif()

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -224,9 +224,9 @@ if (WIN32)
 endif()
 
 option(BUILD_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
+set(COVERAGE_TEST_OPTIONS "--smoketest" CACHE STRING "Command line arguments for hipfft-test when generating a code coverage report")
 if (BUILD_CODE_COVERAGE)
-  set(COVERAGE_COMPILE_FLAGS -g -O0 -fprofile-instr-generate -fcoverage-mapping )
-  target_compile_options( hipfft-test PRIVATE ${COVERAGE_COMPILE_FLAGS} )
+  target_compile_options( hipfft-test PRIVATE -g -O0 -fprofile-instr-generate -fcoverage-mapping )
   target_link_options( hipfft-test INTERFACE -fprofile-instr-generate )
 
   add_custom_target(

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -179,3 +179,8 @@ if( ROCmCMakeBuildTools_FOUND )
       ${static_depends}
     NAMESPACE hip:: )
 endif()
+
+if (BUILD_CODE_COVERAGE)
+  target_compile_options( hipfft PRIVATE -g -O0 -fprofile-instr-generate -fcoverage-mapping )
+  target_link_options( hipfft INTERFACE -fprofile-instr-generate )
+endif()

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -182,5 +182,5 @@ endif()
 
 if (BUILD_CODE_COVERAGE)
   target_compile_options( hipfft PRIVATE -g -O0 -fprofile-instr-generate -fcoverage-mapping )
-  target_link_options( hipfft INTERFACE -fprofile-instr-generate )
+  target_link_options( hipfft PUBLIC -fprofile-instr-generate )
 endif()


### PR DESCRIPTION
Added two new targets, `code_cov_tests` and `coverage`.  

To generate a coverage report, a user can add the -DBUILD_CODE_COVERAGE=ON option to cmake and then run `make -j coverage`.  This will dump the code coverage report to the terminal and also create an html file that can be served or uploaded to Jenkins.

Default `hipfft-test` parameters are `--smoketest`, however, a user can customize their options by setting COVERAGE_TEST_OPTIONS="--arg1=value --arg2=value ...".  See README for more details.