### PR TITLE
hipfft-test: print host memory limit to aid troubleshooting

### DIFF
--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -508,6 +508,7 @@ int main(int argc, char* argv[])
 
     // Set host memory limit from command-line options
     host_memory::singleton().set_limit_gbytes(ramgb);
+    std::cout << "Host memory limit: " << ramgb << " GiB" << std::endl;
 
     if(use_fftw_wisdom)
     {


### PR DESCRIPTION
hipFFT version of https://github.com/ROCm/rocFFT/pull/592 .