### PR TITLE
Revision of hipfft's testing code base

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,12 @@ endif()
 
 # Dependencies
 include(cmake/dependencies.cmake)
+# Note: the above does 'find_package(rocfft REQUIRED)' which eventually
+# includes /opt/rocm/lib/cmake/hip/hip-config-amd.cmake on AMD platforms.
+# The latter does set GPU_TARGETS (cached) to
+# - AMDGPU_TARGETS if it is used (printing a deprecation warning);
+# - the (list of) GPU device(s) automatically detected on the platform if
+#   neither GPU_TARGETS nor AMDGPU_TARGETS is used.
 
 if (BUILD_WITH_COMPILER STREQUAL "HIP-NVCC" )
   set (BUILD_WITH_LIB "CUDA")
@@ -164,14 +170,8 @@ if (BUILD_WITH_COMPILER STREQUAL "HIP-NVCC" )
   set( WARNING_FLAGS ${NVCC_WARNING_FLAGS} )
 
 else()
-  # Define GPU targets
-  if(AMDGPU_TARGETS AND NOT GPU_TARGETS)
-    message( DEPRECATION "AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS." )
-  endif()
-  set(AMDGPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING "Target default GPUs if AMDGPU_TARGETS is not defined. (Deprecated, prefer GPU_TARGETS)")
-  rocm_check_target_ids(AMDGPU_TARGETS TARGETS "${AMDGPU_TARGETS}")
-  # Don't force, users should be able to override GPU_TARGETS at the command line if desired
-  set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for")
+  # Check support for the GPU target(s)
+  rocm_check_target_ids(GPU_TARGETS TARGETS "${GPU_TARGETS}")
   if( BUILD_WITH_COMPILER STREQUAL "HIP-CLANG" )
     set( HIP_PLATFORM "amd" )
     set( HIP_COMPILER "clang" )

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -112,7 +112,7 @@ foreach( target ${TEST_TARGETS} )
       hip::host
       hip::device
     )
-    foreach( gpu_target ${AMDGPU_TARGETS} )
+    foreach( gpu_target ${GPU_TARGETS} )
       target_compile_options( ${target} PRIVATE --offload-arch=${gpu_target} )
     endforeach()
 

--- a/clients/tests/accuracy_test_1D.cpp
+++ b/clients/tests/accuracy_test_1D.cpp
@@ -30,8 +30,6 @@
 #include "../../shared/params_gen.h"
 #include "../../shared/rocfft_against_fftw.h"
 
-using ::testing::ValuesIn;
-
 // TODO: handle special case where length=2 for real/complex transforms.
 const static std::vector<size_t> pow2_range
     = {2,       4,        8,        16,       32,        128,       256,

--- a/clients/tests/accuracy_test_1D.cpp
+++ b/clients/tests/accuracy_test_1D.cpp
@@ -317,29 +317,22 @@ INSTANTIATE_TEST_SUITE_P(DISABLED_offset_mix_1D,
 
 // small 1D sizes just need to make sure our factorization isn't
 // completely broken, so we just check simple C2C outplace interleaved
-INSTANTIATE_TEST_SUITE_P(small_1D,
-                         accuracy_test,
-                         ::testing::ValuesIn(param_generator_base(
-                             test_prob,
-                             {fft_transform_type_complex_forward},
-                             generate_lengths({small_1D_sizes()}),
-                             {fft_precision_single},
-                             {1},
-                             [](fft_transform_type                       t,
-                                const std::vector<fft_result_placement>& place_range,
-                                const bool                               planar) {
-                                 return std::vector<type_place_io_t>{
-                                     std::make_tuple(t,
-                                                     place_range[0],
-                                                     fft_array_type_complex_interleaved,
-                                                     fft_array_type_complex_interleaved)};
-                             },
-                             stride_range,
-                             stride_range,
-                             ioffset_range_zero,
-                             ooffset_range_zero,
-                             {fft_placement_notinplace})),
-                         accuracy_test::TestName);
+INSTANTIATE_TEST_SUITE_P(
+    small_1D,
+    accuracy_test,
+    ::testing::ValuesIn(param_generator_base(test_prob,
+                                             {fft_transform_type_complex_forward},
+                                             generate_lengths({small_1D_sizes()}),
+                                             {fft_precision_single},
+                                             range_for_unbatched,
+                                             generate_types,
+                                             stride_range,
+                                             stride_range,
+                                             ioffset_range_zero,
+                                             ooffset_range_zero,
+                                             {fft_placement_notinplace},
+                                             false /* planar */)),
+    accuracy_test::TestName);
 
 // NB:
 // We have known non-unit strides issues for 1D:
@@ -350,7 +343,7 @@ INSTANTIATE_TEST_SUITE_P(small_1D,
 // main tests.
 //
 // The below test covers non-unit strides, pow of 2, middle sizes, which has SBCC/SBRC kernels
-// invloved.
+// involved.
 const static std::vector<size_t>              pow2_range_for_stride      = {4096, 8192, 524288};
 const static std::vector<size_t>              pow2_range_for_stride_half = {4096, 8192};
 const static std::vector<std::vector<size_t>> stride_range_for_pow2      = {{2}, {3}};
@@ -362,7 +355,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn(param_generator_complex(test_prob,
                                                 generate_lengths({pow2_range_for_stride}),
                                                 precision_range_sp_dp,
-                                                batch_range_1D,
+                                                batch_range_for_stride,
                                                 stride_range_for_pow2,
                                                 stride_range_for_pow2,
                                                 ioffset_range_zero,
@@ -378,7 +371,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn(param_generator_real(test_prob,
                                              generate_lengths({pow2_range_for_stride}),
                                              precision_range_sp_dp,
-                                             batch_range_1D,
+                                             batch_range_for_stride,
                                              stride_range_for_pow2,
                                              stride_range_for_pow2,
                                              ioffset_range_zero,
@@ -394,7 +387,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn(param_generator_real(test_prob,
                                              generate_lengths({pow2_range_for_stride_half}),
                                              {fft_precision_half},
-                                             batch_range_1D,
+                                             batch_range_for_stride,
                                              stride_range_for_pow2,
                                              stride_range_for_pow2,
                                              ioffset_range_zero,
@@ -404,87 +397,27 @@ INSTANTIATE_TEST_SUITE_P(
                                              false)),
     accuracy_test::TestName);
 
-// Create an array parameters for strided 2D batched transforms.
-inline auto
-    param_generator_complex_1d_batched_2d(const double                             base_prob,
-                                          const std::vector<std::vector<size_t>>&  v_lengths,
-                                          const std::vector<fft_precision>&        precision_range,
-                                          const std::vector<std::vector<size_t>>&  ioffset_range,
-                                          const std::vector<std::vector<size_t>>&  ooffset_range,
-                                          const std::vector<fft_result_placement>& place_range)
-{
-
-    std::vector<fft_params> params;
-
-    // for(auto& transform_type :
-    // {fft_transform_type_complex_forward, fft_transform_type_complex_inverse})
-    // {
-
-    for(auto& transform_type : trans_type_range_complex)
-    {
-        for(const auto& lengths : v_lengths)
-        {
-            // try to ensure that we are given literal lengths, not
-            // something to be passed to generate_lengths
-            if(lengths.empty() || lengths.size() > 3)
-            {
-                assert(false);
-                continue;
-            }
-            for(const auto precision : precision_range)
-            {
-                for(const auto& types : generate_types(transform_type, place_range, false))
-                {
-                    for(const auto& ioffset : ioffset_range)
-                    {
-                        for(const auto& ooffset : ooffset_range)
-                        {
-                            fft_params param;
-
-                            param.length         = lengths;
-                            param.istride        = lengths;
-                            param.ostride        = lengths;
-                            param.nbatch         = lengths[0];
-                            param.precision      = precision;
-                            param.transform_type = std::get<0>(types);
-                            param.placement      = std::get<1>(types);
-                            param.idist          = 1;
-                            param.odist          = 1;
-                            param.itype          = std::get<2>(types);
-                            param.otype          = std::get<3>(types);
-                            param.ioffset        = ioffset;
-                            param.ooffset        = ooffset;
-
-                            param.validate();
-
-                            const double roll = hash_prob(random_seed, param.token());
-                            const double run_prob
-                                = base_prob * (param.is_planar() ? complex_planar_prob_factor : 1.0)
-                                  * (param.is_interleaved() ? complex_interleaved_prob_factor : 1.0)
-                                  * (param.is_real() ? real_prob_factor : 1.0);
-
-                            if(roll > run_prob)
-                            {
-                                if(verbose > 4)
-                                {
-                                    std::cout << "Test skipped (probability " << run_prob << " > "
-                                              << roll << ")\n";
-                                }
-                                continue;
-                            }
-                            if(param.valid(0))
-                            {
-                                params.push_back(param);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    return params;
-}
+inline auto param_generator_complex_1d_batched_2d =
+    [](const double                             base_prob,
+       const std::vector<std::vector<size_t>>&  v_lengths,
+       const std::vector<fft_precision>&        precision_range,
+       const std::vector<std::vector<size_t>>&  ioffset_range,
+       const std::vector<std::vector<size_t>>&  ooffset_range,
+       const std::vector<fft_result_placement>& place_range) {
+    return param_generator_base(base_prob,
+                                trans_type_range_complex,
+                                v_lengths,
+                                precision_range,
+                                inner_batch_generator(),
+                                generate_types,
+                                inner_batch_stride_generator(),
+                                inner_batch_stride_generator(),
+                                ioffset_range,
+                                ooffset_range,
+                                place_range,
+                                false  /*planar*/,
+                                false  /*run_callbacks*/);
+};
 
 const static std::vector<size_t> pow2_range_2D
     = {2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192};

--- a/clients/tests/accuracy_test_1D.cpp
+++ b/clients/tests/accuracy_test_1D.cpp
@@ -397,27 +397,27 @@ INSTANTIATE_TEST_SUITE_P(
                                              false)),
     accuracy_test::TestName);
 
-inline auto param_generator_complex_1d_batched_2d =
-    [](const double                             base_prob,
-       const std::vector<std::vector<size_t>>&  v_lengths,
-       const std::vector<fft_precision>&        precision_range,
-       const std::vector<std::vector<size_t>>&  ioffset_range,
-       const std::vector<std::vector<size_t>>&  ooffset_range,
-       const std::vector<fft_result_placement>& place_range) {
-    return param_generator_base(base_prob,
-                                trans_type_range_complex,
-                                v_lengths,
-                                precision_range,
-                                inner_batch_generator(),
-                                generate_types,
-                                inner_batch_stride_generator(),
-                                inner_batch_stride_generator(),
-                                ioffset_range,
-                                ooffset_range,
-                                place_range,
-                                false  /*planar*/,
-                                false  /*run_callbacks*/);
-};
+inline auto param_generator_complex_1d_batched_2d
+    = [](const double                             base_prob,
+         const std::vector<std::vector<size_t>>&  v_lengths,
+         const std::vector<fft_precision>&        precision_range,
+         const std::vector<std::vector<size_t>>&  ioffset_range,
+         const std::vector<std::vector<size_t>>&  ooffset_range,
+         const std::vector<fft_result_placement>& place_range) {
+          return param_generator_base(base_prob,
+                                      trans_type_range_complex,
+                                      v_lengths,
+                                      precision_range,
+                                      inner_batch_generator(),
+                                      generate_types,
+                                      inner_batch_stride_generator(),
+                                      inner_batch_stride_generator(),
+                                      ioffset_range,
+                                      ooffset_range,
+                                      place_range,
+                                      false /*planar*/,
+                                      false /*run_callbacks*/);
+      };
 
 const static std::vector<size_t> pow2_range_2D
     = {2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192};

--- a/clients/tests/accuracy_test_2D.cpp
+++ b/clients/tests/accuracy_test_2D.cpp
@@ -30,8 +30,6 @@
 #include "../../shared/params_gen.h"
 #include "../../shared/rocfft_against_fftw.h"
 
-using ::testing::ValuesIn;
-
 // Set parameters
 
 // TODO: enable 16384, 32768 when omp support is available (takes too

--- a/clients/tests/accuracy_test_3D.cpp
+++ b/clients/tests/accuracy_test_3D.cpp
@@ -30,8 +30,6 @@
 #include "../../shared/params_gen.h"
 #include "../../shared/rocfft_against_fftw.h"
 
-using ::testing::ValuesIn;
-
 // Set parameters
 
 // TODO: 512, 1024, 2048 make the tests take too long; re-enable when

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -48,6 +48,7 @@ int verbose;
 
 // User-defined random seed
 size_t random_seed;
+std::random_device default_seed_dev;
 // Overall probability of running conventional tests
 double test_prob;
 // Modifier for probability of running tests with complex interleaved data
@@ -101,6 +102,8 @@ fft_params::fft_mp_lib mp_lib = fft_params::fft_mp_lib_none;
 int mp_ranks = 1;
 // Multi-process launch command (e.g. mpirun --np 4 /path/to/hipfft_mpi_worker)
 std::string mp_launch;
+
+static std::string config_file_to_save;
 
 void init_gtest_flags()
 {
@@ -277,7 +280,10 @@ int main(int argc, char* argv[])
         "      HP - hermitian planar\n"
         "\n"
         "Usage"};
-
+    auto* rt_default_opts =
+        app.add_option_group("Options with runtime-defined default values",
+                             "Option values are saved/reported in case of test "
+                             "failure (even if not set explicitly)");
     // Override CLI11 help to print after later CLI11 options that are defined, and allow gtest's help
     app.set_help_flag("");
     CLI::Option* opt_help = app.add_flag("-h, --help", "Produces this help message");
@@ -323,21 +329,22 @@ int main(int argc, char* argv[])
         ->each([&](const std::string&) {
             if(mp_lib == fft_params::fft_mp_lib_none)
             {
-                std::cout << "--mp_launch requires an mp library (see mp_lib in --help).\n";
-                std::exit(-1);
+                throw CLI::ValidationError("--mp_launch requires an mp library (see mp_lib in --help)");
             }
         })
         ->needs("--mp_lib");
-    // FIXME: Seed has no use currently
-    // CLI::Option* opt_seed =
-    app.add_option("--seed", random_seed, "Random seed; if unset, use an actual random seed");
+    rt_default_opts->add_option(
+        "--seed", random_seed, "Random seed; if unset, use an actual random seed")
+        ->default_val(default_seed_dev());
     app.add_flag("--smoketest", "Run a short (approx 5 minute) randomized selection of tests")
         ->each([&](const std::string&) {
             // The objective is to have an test that takes about 5 minutes, so just set the probability
             // per test to a small value to achieve this result.
             test_prob = 0.002;
         });
-
+    app.set_config("--load_config_file",
+                   "" /* none by default */,
+                   "Path to a readable file defining a test configuration to read");
     // Try parsing initial args that will be used to configure tests
     // Allow extras to pass on gtest and hipFFT arguments without error
     app.allow_extras();
@@ -424,7 +431,7 @@ int main(int argc, char* argv[])
     non_token->add_option("--ooffset", manual_params.ooffset, "Output offset");
     app.add_option("--isize", manual_params.isize, "Logical size of input buffer");
     app.add_option("--osize", manual_params.osize, "Logical size of output buffer");
-    app.add_option("--R", ramgb, "RAM limit in GiB for tests")
+    rt_default_opts->add_option("--R", ramgb, "RAM limit in GiB for tests")
         ->default_val(host_memory::singleton().get_total_gbytes());
     app.add_option("--V", vramgb, "VRAM limit in GiB for tests")->default_val(0);
     app.add_option("--half_epsilon", half_epsilon)->default_val(9.77e-4);
@@ -449,6 +456,11 @@ int main(int argc, char* argv[])
                    "1) PRNG sequence (host)\n"
                    "2) linearly-spaced sequence (device)\n"
                    "3) linearly-spaced sequence (host)");
+    app.add_option("--save_config_filename",
+                   config_file_to_save,
+                   "Relative path to a writeable file where the test configuration is "
+                   "to be saved, if the test failed.")
+                   ->default_val("saved_hipfft-test.conf");
 
     // Parse rest of args and catch any errors here
     try
@@ -477,6 +489,7 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
+    std::cout << "Using random_seed = " << random_seed << std::endl;
     std::cout << "half epsilon: " << half_epsilon << "\tsingle epsilon: " << single_epsilon
               << "\tdouble epsilon: " << double_epsilon << std::endl;
 
@@ -608,6 +621,34 @@ int main(int argc, char* argv[])
     std::cout << "single precision max l2 epsilon:     " << max_l2_eps_single << std::endl;
     std::cout << "double precision max l-inf epsilon: " << max_linf_eps_double << std::endl;
     std::cout << "double precision max l2 epsilon:     " << max_l2_eps_double << std::endl;
+
+    if (retval != EXIT_SUCCESS) {
+        constexpr bool print_default_too = true;
+        std::string conf = app.config_to_str(!print_default_too);
+        // The above exports values for all configuration options set by the user.
+        // Default-initialized option values are not included: add those initialized
+        // at runtime separately to ease reproducibility of reported failure(s)
+        for (auto* opt : rt_default_opts->get_options()) {
+            // remove option from from group if explicitly set to avoid
+            // ill-constructed configuration files due to duplication(s)
+            if (*opt) rt_default_opts->remove_option(opt);
+        }
+        conf += rt_default_opts->config_to_str(print_default_too);
+        try {
+            std::ofstream outputFile(config_file_to_save);
+            if (!outputFile.is_open())
+                throw std::runtime_error(config_file_to_save + ": file could not be opened");
+            outputFile << conf;
+            outputFile.close();
+            std::cout << "Test configuration successfully saved to "
+                      << config_file_to_save << std::endl;
+        } catch(const std::exception& e) {
+            std::cout << "Failed to save configuration to " << config_file_to_save
+                      << "Exception caught: \n"<< e.what() << std::endl;
+            std::cout << "Configuration: \n"
+                      << conf << std::endl;
+        }
+    }
 
     // rocfft_cleanup();
     return retval;

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -46,15 +46,10 @@
 // Control output verbosity:
 int verbose;
 
-// Run a short (~5 min) test suite by setting test_prob to an appropriate value
-bool smoketest = false;
-
 // User-defined random seed
 size_t random_seed;
 // Overall probability of running conventional tests
 double test_prob;
-// Probability of running tests from the emulation suite
-double emulation_prob;
 // Modifier for probability of running tests with complex interleaved data
 double complex_interleaved_prob_factor;
 // Modifier for probability of running tests with real data
@@ -104,7 +99,7 @@ last_cpu_fft_cache last_cpu_fft_data;
 fft_params::fft_mp_lib mp_lib = fft_params::fft_mp_lib_none;
 // Number of multi-process ranks to launch
 int mp_ranks = 1;
-// Multi-process launch command (e.g. mpirun --np 4 /path/to/rocfft_mpi_worker)
+// Multi-process launch command (e.g. mpirun --np 4 /path/to/hipfft_mpi_worker)
 std::string mp_launch;
 
 void init_gtest_flags()
@@ -280,12 +275,22 @@ int main(int argc, char* argv[])
     app.add_option("--test_prob", test_prob, "Probability of running individual tests")
         ->default_val(1.0)
         ->check(CLI::Range(0.0, 1.0));
+    app.add_option("--real_prob",
+                   real_prob_factor,
+                   "Probability multiplier for running individual real/complex transforms")
+        ->default_val(1.0)
+        ->check(CLI::PositiveNumber);
+    app.add_option("--planar_prob",
+                   complex_planar_prob_factor,
+                   "Probability multiplier for running individual planar transforms")
+        ->default_val(0.1)
+        ->check(CLI::PositiveNumber);
     app.add_option(
            "--complex_interleaved_prob_factor",
            complex_interleaved_prob_factor,
            "Probability multiplier for running individual transforms with complex interleaved data")
         ->default_val(1)
-        ->check(CLI::NonNegativeNumber);
+        ->check(CLI::PositiveNumber);
     app.add_option("--callback_prob",
                    callback_prob_factor,
                    "Probability multiplier for running individual callback transforms")
@@ -302,7 +307,7 @@ int main(int argc, char* argv[])
     app.add_option("--mp_launch",
                    mp_launch,
                    "Command line prefix to launch multi-process transforms, e.g. \"mpirun --np 4 "
-                   "/path/to/rocfft_mpi_worker\"")
+                   "/path/to/hipfft_mpi_worker\"")
         ->default_val("")
         ->each([&](const std::string&) {
             if(mp_lib == fft_params::fft_mp_lib_none)

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -178,13 +178,6 @@ void precompile_test_kernels(const std::string& precompile_file)
                 // check on the test suite's name (i.e., if it includes "accuracy_test").
                 // That would allow other (hypothetical) accuracy test instances than
                 // "vs_fftw/" to be considered as well...
-                // Requirement: TEST(manual, vs_fftw) to be changed
-                // - either as TEST(manual_accuracy_test, vs_fftw);
-                // - or as INSTANTIATE_TEST_SUITE_P(manual,
-                //                                  accuracy_test,
-                //                                  ::testing::ValuesIn({manual_param}),
-                //                                  accuracy_test::TestName);
-                // (preference for second option)
                 name.erase(0, 8);
 
                 // change batch to 1, so we don't waste time creating
@@ -342,54 +335,23 @@ int main(int argc, char* argv[])
             // per test to a small value to achieve this result.
             test_prob = 0.002;
         });
+    // Token string to fully specify fft params for the manual test.
+    std::string test_token;
+    CLI::Option* opt_token
+        = app.add_option("--token", test_token, "Test token name for manual test")->default_val("");
     app.set_config("--load_config_file",
                    "" /* none by default */,
                    "Path to a readable file defining a test configuration to read");
-    // Try parsing initial args that will be used to configure tests
-    // Allow extras to pass on gtest and hipFFT arguments without error
-    app.allow_extras();
-    try
-    {
-        app.parse(argc, argv);
-    }
-    catch(const CLI::ParseError& e)
-    {
-        return app.exit(e);
-    }
-
-    // NB: If we initialize gtest first, then it removes all of its own command-line
-    // arguments and sets argc and argv correctly;
-    ::testing::InitGoogleTest(&argc, argv);
-
-    // Filename for fftw and fftwf wisdom.
-    std::string fftw_wisdom_filename;
-
-    // Token string to fully specify fft params for the manual test.
-    std::string test_token;
-
-    // Filename for precompiled kernels to be written to
-    std::string precompile_file;
-
-    // Declare the supported options. Some option pointers are declared to track passed opts.
-    app.add_flag("--callback", "Inject load/store callbacks")->each([&](const std::string&) {
-        manual_params.run_callbacks = true;
-    });
-    // app.add_flag("--version", "Print queryable version information from the rocfft library")
-    //     ->each([](const std::string&) {
-    //         rocfft_setup();
-    //         char v[256];
-    //         rocfft_get_version_string(v, 256);
-    //         std::cout << "rocFFT version: " << v << std::endl;
-    //         return EXIT_SUCCESS;
-    //     });
-    CLI::Option* opt_token
-        = app.add_option("--token", test_token, "Test token name for manual test")->default_val("");
     // Group together options that conflict with --token
     auto* non_token = app.add_option_group("Token Conflict", "Options excluded by --token");
+    non_token->excludes(opt_token);
+    // Declare the supported options. Some option pointers are declared to track passed opts.
+    non_token->add_flag("--callback", "Inject load/store callbacks")->each([&](const std::string&) {
+        manual_params.run_callbacks = true;
+    });
     non_token
         ->add_flag("--double", "Double precision transform (deprecated: use --precision double)")
         ->each([&](const std::string&) { manual_params.precision = fft_precision_double; });
-    non_token->excludes(opt_token);
     non_token
         ->add_option("-t, --transformType",
                      manual_params.transform_type,
@@ -429,8 +391,87 @@ int main(int argc, char* argv[])
         ->default_val(0);
     non_token->add_option("--ioffset", manual_params.ioffset, "Input offset");
     non_token->add_option("--ooffset", manual_params.ooffset, "Output offset");
-    app.add_option("--isize", manual_params.isize, "Logical size of input buffer");
-    app.add_option("--osize", manual_params.osize, "Logical size of output buffer");
+    non_token->add_option("--isize", manual_params.isize, "Logical size of input buffer");
+    non_token->add_option("--osize", manual_params.osize, "Logical size of output buffer");
+    non_token->add_option("--scalefactor", manual_params.scale_factor, "Scale factor to apply to output");
+    // Default value is set in fft_params.h based on if device-side PRNG was enabled.
+    non_token->add_option("-g, --inputGen",
+                   manual_params.igen,
+                   "Input data generation:\n0) PRNG sequence (device)\n"
+                   "1) PRNG sequence (host)\n"
+                   "2) linearly-spaced sequence (device)\n"
+                   "3) linearly-spaced sequence (host)");
+    // Try parsing initial args that will be used to configure tests
+    // Allow extras to pass on gtest and hipFFT arguments without error
+    app.allow_extras();
+    try
+    {
+        app.parse(argc, argv);
+    }
+    catch(const CLI::ParseError& e)
+    {
+        return app.exit(e);
+    }
+
+    if(!test_token.empty())
+    {
+        std::cout << "Reading fft params from token:\n" << test_token << std::endl;
+
+        try
+        {
+            manual_params.from_token(test_token);
+            std::cout << "manual_params.token() = " << manual_params.token() << std::endl;
+        }
+        catch(...)
+        {
+            std::cout << "Unable to parse token." << std::endl;
+            return 1;
+        }
+    }
+    if (manual_params.length.empty())
+    {
+        manual_params.length.push_back(8);
+        // TODO: add random size?
+    }
+
+    if(manual_params.istride.empty())
+    {
+        manual_params.istride.push_back(1);
+        // TODO: add random size?
+    }
+
+    if(manual_params.ostride.empty())
+    {
+        manual_params.ostride.push_back(1);
+        // TODO: add random size?
+    }
+
+    // User-settable options defining the values of all the actual test parameters
+    // (e.g., probability factors and value of manual_params) must be handled
+    // before invoking ::testing::InitGoogleTest as it triggers evaluation of said
+    // parameters (e.g., args of "::testing::Values{In}" in instantiations of test
+    // suites).
+    // set any "unset" parameters of manual_params before initiating gtests
+    // (makes the token reported by gtest less ambiguous)
+    manual_params.validate();
+    // NB: If we initialize gtest first, then it removes all of its own command-line
+    // arguments and sets argc and argv correctly;
+    ::testing::InitGoogleTest(&argc, argv);
+
+    // Filename for fftw and fftwf wisdom.
+    std::string fftw_wisdom_filename;
+
+    // Filename for precompiled kernels to be written to
+    std::string precompile_file;
+
+    // app.add_flag("--version", "Print queryable version information from the rocfft library")
+    //     ->each([](const std::string&) {
+    //         rocfft_setup();
+    //         char v[256];
+    //         rocfft_get_version_string(v, 256);
+    //         std::cout << "rocFFT version: " << v << std::endl;
+    //         return EXIT_SUCCESS;
+    //     });
     rt_default_opts->add_option("--R", ramgb, "RAM limit in GiB for tests")
         ->default_val(host_memory::singleton().get_total_gbytes());
     app.add_option("--V", vramgb, "VRAM limit in GiB for tests")->default_val(0);
@@ -444,18 +485,10 @@ int main(int argc, char* argv[])
     app.add_option("-w, --wise", use_fftw_wisdom, "Use FFTW wisdom");
     app.add_option("-W, --wisdomfile", fftw_wisdom_filename, "FFTW3 wisdom filename")
         ->default_val("wisdom3.txt");
-    app.add_option("--scalefactor", manual_params.scale_factor, "Scale factor to apply to output");
     app.add_option("--precompile",
                    precompile_file,
                    "Precompile kernels to a file for all test cases before running tests")
         ->default_val("");
-    // Default value is set in fft_params.h based on if device-side PRNG was enabled.
-    app.add_option("-g, --inputGen",
-                   manual_params.igen,
-                   "Input data generation:\n0) PRNG sequence (device)\n"
-                   "1) PRNG sequence (host)\n"
-                   "2) linearly-spaced sequence (device)\n"
-                   "3) linearly-spaced sequence (host)");
     app.add_option("--save_config_filename",
                    config_file_to_save,
                    "Relative path to a writeable file where the test configuration is "
@@ -492,24 +525,6 @@ int main(int argc, char* argv[])
     std::cout << "Using random_seed = " << random_seed << std::endl;
     std::cout << "half epsilon: " << half_epsilon << "\tsingle epsilon: " << single_epsilon
               << "\tdouble epsilon: " << double_epsilon << std::endl;
-
-    if(manual_params.length.empty())
-    {
-        manual_params.length.push_back(8);
-        // TODO: add random size?
-    }
-
-    if(manual_params.istride.empty())
-    {
-        manual_params.istride.push_back(1);
-        // TODO: add random size?
-    }
-
-    if(manual_params.ostride.empty())
-    {
-        manual_params.ostride.push_back(1);
-        // TODO: add random size?
-    }
 
     // if precompiling, tell rocFFT to use the specified cache file
     // to write kernels to
@@ -584,21 +599,6 @@ int main(int argc, char* argv[])
         fftwf_import_wisdom_from_string(fftwf_wisdom.c_str());
     }
 
-    if(!test_token.empty())
-    {
-        std::cout << "Reading fft params from token:\n" << test_token << std::endl;
-
-        try
-        {
-            manual_params.from_token(test_token);
-        }
-        catch(...)
-        {
-            std::cout << "Unable to parse token." << std::endl;
-            return 1;
-        }
-    }
-
     if(!precompile_file.empty())
         precompile_test_kernels(precompile_file);
 
@@ -654,34 +654,9 @@ int main(int argc, char* argv[])
     return retval;
 }
 
-TEST(manual, vs_fftw)
-{
-    // Run an individual test using the provided command-line parameters.
-
-    std::cout << "Manual test:" << std::endl;
-
-    manual_params.validate();
-
-    std::cout << "Token: " << manual_params.token() << std::endl;
-
-    hipfft_params params(manual_params);
-
-    try
-    {
-        fft_vs_reference(params, false);
-    }
-    catch(HOSTBUF_MEM_USAGE& e)
-    {
-        // explicitly clear test cache
-        last_cpu_fft_data = last_cpu_fft_cache();
-        GTEST_SKIP() << e.msg;
-    }
-    catch(ROCFFT_SKIP& e)
-    {
-        GTEST_SKIP() << e.msg;
-    }
-    catch(ROCFFT_FAIL& e)
-    {
-        GTEST_FAIL() << e.msg;
-    }
-}
+// instantiation of the paramameterized accuracy_test for the
+// configuration set manually:
+INSTANTIATE_TEST_SUITE_P(manual,
+                         accuracy_test,
+                         ::testing::Values(manual_params),
+                         accuracy_test::TestName);

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -103,6 +103,10 @@ int mp_ranks = 1;
 // Multi-process launch command (e.g. mpirun --np 4 /path/to/hipfft_mpi_worker)
 std::string mp_launch;
 
+const static std::string hipfft_test_load_opt = "--load_config_file";
+const static std::string gtest_flagfile_opt = "--gtest_flagfile=";
+const static std::string hipfft_test_conf_ext = ".hipfft-test.conf";
+const static std::string gtest_conf_ext = ".gtest.conf";
 static std::string config_file_to_save;
 
 void init_gtest_flags()
@@ -253,7 +257,8 @@ void precompile_test_kernels(const std::string& precompile_file)
 }
 
 // helper function including some testing
-static inline int get_hipfft_version(){
+static inline int get_hipfft_version()
+{
     // TODO: this segfaults, fix in hipFFT and enable here
     // EXPECT_EQ(hipfftGetVersion(nullptr), HIPFFT_INVALID_VALUE);
     int v;
@@ -261,6 +266,110 @@ static inline int get_hipfft_version(){
     // maybe possible to verify v (e.g. by comparison with compile-time-defined
     // values defined in some backend's header)?
     return v;
+}
+
+static std::string get_file_content(const std::string& filename)
+{
+    std::ifstream file(filename);
+    if (!file.is_open())
+    {
+        throw std::runtime_error(filename + " could not be opened for reading");
+    }
+    auto content = std::string(std::istreambuf_iterator<char>(file),
+                               std::istreambuf_iterator<char>());
+    file.close();
+    return content;
+}
+
+static void save_to_file(const std::string& content_to_save,
+                         const std::string& filename)
+{
+    if (content_to_save.empty())
+        return;
+    std::ifstream file_check(filename);
+    if (file_check.is_open())
+    {
+        const auto existing_content = get_file_content(filename);
+        file_check.close();
+        if (existing_content == content_to_save)
+            return; // existing file is as required, no need to overwrite it
+        throw std::runtime_error("Refusing to overwrite existing " + filename);
+    }
+    std::ofstream out_file(filename);
+    if (!out_file.is_open())
+        throw std::runtime_error(filename + " could not be opened for writing");
+    out_file << content_to_save;
+    out_file.close();
+}
+
+static void report_failing_configuration(const std::string& exe,
+                                         const CLI::App& app,
+                                         CLI::Option_group* rt_default_opts,
+                                         const std::vector<std::string>& gtest_args)
+{
+    constexpr bool print_default_too = true;
+    std::string hipfft_test_options = app.config_to_str(!print_default_too);
+    // The above exports values for all options set by the user.
+    // Default-initialized option values are not included: add those initialized
+    // at runtime separately to ease reproducibility of reported failure(s)
+    for (auto* opt : rt_default_opts->get_options())
+    {
+        // remove option from group if explicitly set to avoid
+        // ill-constructed configuration files due to duplication(s)
+        if (*opt) rt_default_opts->remove_option(opt);
+    }
+    hipfft_test_options += rt_default_opts->config_to_str(print_default_too);
+    std::string gtest_flagfile_content;
+    for (auto flag : gtest_args)
+    {
+        if (flag.find(gtest_flagfile_opt) != std::string::npos)
+        {
+            // avoid generating a recursive inclusion of gtest flagfiles
+            // if possible: copy content of file that was used instead
+            try
+            {
+                gtest_flagfile_content += get_file_content(flag.substr(gtest_flagfile_opt.length()));
+            }
+            catch (const std::exception& e)
+            {
+                if (verbose)
+                {
+                    std::cout << "Resorting to use recursive flagfiles" << std::endl;
+                }
+                gtest_flagfile_content += flag;
+            }
+        } else {
+            gtest_flagfile_content += flag;
+        }
+        if (gtest_flagfile_content.back() != '\n')
+        {
+            gtest_flagfile_content += "\n";
+        }
+    }
+    const std::string hipfft_test_config_file_to_save = config_file_to_save + hipfft_test_conf_ext;
+    const std::string gtest_config_file_to_save = config_file_to_save + gtest_conf_ext;
+    try {
+        save_to_file(hipfft_test_options, hipfft_test_config_file_to_save);
+        save_to_file(gtest_flagfile_content, gtest_config_file_to_save);
+        std::cout << "\nFailure(s) should be reproduced by \n\t"
+                    << exe;
+        if (!hipfft_test_config_file_to_save.empty())
+            std::cout << " " << hipfft_test_load_opt << " " << hipfft_test_config_file_to_save;
+        if (!gtest_flagfile_content.empty())
+            std::cout << " " << gtest_flagfile_opt << gtest_config_file_to_save;
+        std::cout << std::endl;
+    } catch (const std::exception& e)
+    {
+        std::cout << "\nFailed to save configuration to designated file(s).\n"
+                    << "\tException caught: "<< e.what() << "\n";
+        if (!hipfft_test_options.empty())
+            std::cout << "\nUsed hipfft-test options: \n"
+                        << hipfft_test_options;
+        if (!gtest_flagfile_content.empty())
+            std::cout << "\nUsed gtest flags: \n"
+                        << gtest_flagfile_content << "\n";
+        std::cout << std::endl;
+    }
 }
 
 int main(int argc, char* argv[])
@@ -350,7 +459,7 @@ int main(int argc, char* argv[])
     std::string test_token;
     CLI::Option* opt_token
         = app.add_option("--token", test_token, "Test token name for manual test")->default_val("");
-    app.set_config("--load_config_file",
+    app.set_config(hipfft_test_load_opt,
                    "" /* none by default */,
                    "Path to a readable file defining a test configuration to read");
     // Group together options that conflict with --token
@@ -469,8 +578,28 @@ int main(int argc, char* argv[])
     manual_params.validate();
     // NB: If we initialize gtest first, then it removes all of its own command-line
     // arguments and sets argc and argv correctly;
-    ::testing::InitGoogleTest(&argc, argv);
-
+    // Determine gtest args by identification of the argv set excluded by InitGoogleTest
+    std::vector<std::string> gtest_args;
+    int argv_idx = 0;
+    for (; argv_idx < argc; argv_idx++)
+        gtest_args.push_back(argv[argv_idx]);   // all argv values are copied
+    ::testing::InitGoogleTest(&argc, argv);     // gtest args are removed
+    // identify what was removed (assuming removals didn't change ordering)
+    auto arg = gtest_args.begin(); argv_idx = 0;
+    while (argv_idx < argc && arg != gtest_args.end())
+    {
+        if (*arg == argv[argv_idx])
+        {
+            // argument not removed --> not specific to gtests
+            arg = gtest_args.erase(arg, arg+1);
+            argv_idx++;
+        }
+        else
+        {
+            // arg is specific to gtest
+            arg++;
+        }
+    }
     // Filename for fftw and fftwf wisdom.
     std::string fftw_wisdom_filename;
 
@@ -494,11 +623,13 @@ int main(int argc, char* argv[])
                    precompile_file,
                    "Precompile kernels to a file for all test cases before running tests")
         ->default_val("");
-    app.add_option("--save_config_filename",
+    app.add_option("--save_config",
                    config_file_to_save,
-                   "Relative path to a writeable file where the test configuration is "
-                   "to be saved, if the test failed.")
-                   ->default_val("saved_hipfft-test.conf");
+                   "File(s) where the test options are to be written out, "
+                   "if the test fails.\nUp to two files may be created, "
+                    "with extensions \"" + hipfft_test_conf_ext + "\" and/or \""
+                    + gtest_conf_ext +"\" added to this file name")
+                   ->default_val("saved_failed_test");
 
     // Parse rest of args and catch any errors here
     try
@@ -516,10 +647,13 @@ int main(int argc, char* argv[])
         return EXIT_SUCCESS;
     }
     const int hipfft_version = get_hipfft_version();
-    // print it regardless:
-    std::cout << "hipFFT version: " << hipfft_version << std::endl;
-    if (*opt_version) {
-        return EXIT_SUCCESS;
+    if (*opt_version || verbose > 0)
+    {
+        std::cout << "hipFFT version: " << hipfft_version << std::endl;
+        if (*opt_version)
+        {
+            return EXIT_SUCCESS;
+        }
     }
 
     // Ensure there are no leftover options used by neither gtest nor CLI11
@@ -628,32 +762,9 @@ int main(int argc, char* argv[])
     std::cout << "double precision max l-inf epsilon: " << max_linf_eps_double << std::endl;
     std::cout << "double precision max l2 epsilon:     " << max_l2_eps_double << std::endl;
 
-    if (retval != EXIT_SUCCESS) {
-        constexpr bool print_default_too = true;
-        std::string conf = app.config_to_str(!print_default_too);
-        // The above exports values for all configuration options set by the user.
-        // Default-initialized option values are not included: add those initialized
-        // at runtime separately to ease reproducibility of reported failure(s)
-        for (auto* opt : rt_default_opts->get_options()) {
-            // remove option from from group if explicitly set to avoid
-            // ill-constructed configuration files due to duplication(s)
-            if (*opt) rt_default_opts->remove_option(opt);
-        }
-        conf += rt_default_opts->config_to_str(print_default_too);
-        try {
-            std::ofstream outputFile(config_file_to_save);
-            if (!outputFile.is_open())
-                throw std::runtime_error(config_file_to_save + ": file could not be opened");
-            outputFile << conf;
-            outputFile.close();
-            std::cout << "Test configuration successfully saved to "
-                      << config_file_to_save << std::endl;
-        } catch(const std::exception& e) {
-            std::cout << "Failed to save configuration to " << config_file_to_save
-                      << "Exception caught: \n"<< e.what() << std::endl;
-            std::cout << "Configuration: \n"
-                      << conf << std::endl;
-        }
+    if (retval != EXIT_SUCCESS)
+    {
+        report_failing_configuration(argv[0], app, rt_default_opts, gtest_args);
     }
 
     return retval;

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -252,6 +252,17 @@ void precompile_test_kernels(const std::string& precompile_file)
               << " ms\n";
 }
 
+// helper function including some testing
+static inline int get_hipfft_version(){
+    // TODO: this segfaults, fix in hipFFT and enable here
+    // EXPECT_EQ(hipfftGetVersion(nullptr), HIPFFT_INVALID_VALUE);
+    int v;
+    EXPECT_EQ(hipfftGetVersion(&v), HIPFFT_SUCCESS);
+    // maybe possible to verify v (e.g. by comparison with compile-time-defined
+    // values defined in some backend's header)?
+    return v;
+}
+
 int main(int argc, char* argv[])
 {
     CLI::App app{
@@ -401,6 +412,8 @@ int main(int argc, char* argv[])
                    "1) PRNG sequence (host)\n"
                    "2) linearly-spaced sequence (device)\n"
                    "3) linearly-spaced sequence (host)");
+    CLI::Option* opt_version = app.add_flag("--version",
+        "Print queryable version information from the hipfft library's backend");
     // Try parsing initial args that will be used to configure tests
     // Allow extras to pass on gtest and hipFFT arguments without error
     app.allow_extras();
@@ -464,14 +477,6 @@ int main(int argc, char* argv[])
     // Filename for precompiled kernels to be written to
     std::string precompile_file;
 
-    // app.add_flag("--version", "Print queryable version information from the rocfft library")
-    //     ->each([](const std::string&) {
-    //         rocfft_setup();
-    //         char v[256];
-    //         rocfft_get_version_string(v, 256);
-    //         std::cout << "rocFFT version: " << v << std::endl;
-    //         return EXIT_SUCCESS;
-    //     });
     rt_default_opts->add_option("--R", ramgb, "RAM limit in GiB for tests")
         ->default_val(host_memory::singleton().get_total_gbytes());
     app.add_option("--V", vramgb, "VRAM limit in GiB for tests")->default_val(0);
@@ -510,6 +515,12 @@ int main(int argc, char* argv[])
         std::cout << app.help() << "\n";
         return EXIT_SUCCESS;
     }
+    const int hipfft_version = get_hipfft_version();
+    // print it regardless:
+    std::cout << "hipFFT version: " << hipfft_version << std::endl;
+    if (*opt_version) {
+        return EXIT_SUCCESS;
+    }
 
     // Ensure there are no leftover options used by neither gtest nor CLI11
     std::vector<std::string> remaining_args = app.remaining();
@@ -537,11 +548,6 @@ int main(int argc, char* argv[])
         env_precompile = std::make_unique<EnvironmentSetTemp>("ROCFFT_RTC_CACHE_PATH",
                                                               precompile_file.c_str());
     }
-
-    // rocfft_setup();
-    // char v[256];
-    // rocfft_get_version_string(v, 256);
-    // std::cout << "rocFFT version: " << v << std::endl;
 
 #ifdef FFTW_MULTITHREAD
     fftw_init_threads();
@@ -650,7 +656,6 @@ int main(int argc, char* argv[])
         }
     }
 
-    // rocfft_cleanup();
     return retval;
 }
 

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -171,6 +171,17 @@ void precompile_test_kernels(const std::string& precompile_file)
             // only care about accuracy tests
             if(name.find("vs_fftw/") != std::string::npos)
             {
+                // [possible TODO] move above check to nesting loop's scope as a
+                // check on the test suite's name (i.e., if it includes "accuracy_test").
+                // That would allow other (hypothetical) accuracy test instances than
+                // "vs_fftw/" to be considered as well...
+                // Requirement: TEST(manual, vs_fftw) to be changed
+                // - either as TEST(manual_accuracy_test, vs_fftw);
+                // - or as INSTANTIATE_TEST_SUITE_P(manual,
+                //                                  accuracy_test,
+                //                                  ::testing::ValuesIn({manual_param}),
+                //                                  accuracy_test::TestName);
+                // (preference for second option)
                 name.erase(0, 8);
 
                 // change batch to 1, so we don't waste time creating

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -47,7 +47,7 @@
 int verbose;
 
 // User-defined random seed
-size_t random_seed;
+size_t             random_seed;
 std::random_device default_seed_dev;
 // Overall probability of running conventional tests
 double test_prob;
@@ -104,10 +104,10 @@ int mp_ranks = 1;
 std::string mp_launch;
 
 const static std::string hipfft_test_load_opt = "--load_config_file";
-const static std::string gtest_flagfile_opt = "--gtest_flagfile=";
+const static std::string gtest_flagfile_opt   = "--gtest_flagfile=";
 const static std::string hipfft_test_conf_ext = ".hipfft-test.conf";
-const static std::string gtest_conf_ext = ".gtest.conf";
-static std::string config_file_to_save;
+const static std::string gtest_conf_ext       = ".gtest.conf";
+static std::string       config_file_to_save;
 
 void init_gtest_flags()
 {
@@ -271,103 +271,105 @@ static inline int get_hipfft_version()
 static std::string get_file_content(const std::string& filename)
 {
     std::ifstream file(filename);
-    if (!file.is_open())
+    if(!file.is_open())
     {
         throw std::runtime_error(filename + " could not be opened for reading");
     }
-    auto content = std::string(std::istreambuf_iterator<char>(file),
-                               std::istreambuf_iterator<char>());
+    auto content
+        = std::string(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
     file.close();
     return content;
 }
 
-static void save_to_file(const std::string& content_to_save,
-                         const std::string& filename)
+static void save_to_file(const std::string& content_to_save, const std::string& filename)
 {
-    if (content_to_save.empty())
+    if(content_to_save.empty())
         return;
     std::ifstream file_check(filename);
-    if (file_check.is_open())
+    if(file_check.is_open())
     {
         const auto existing_content = get_file_content(filename);
         file_check.close();
-        if (existing_content == content_to_save)
+        if(existing_content == content_to_save)
             return; // existing file is as required, no need to overwrite it
         throw std::runtime_error("Refusing to overwrite existing " + filename);
     }
     std::ofstream out_file(filename);
-    if (!out_file.is_open())
+    if(!out_file.is_open())
         throw std::runtime_error(filename + " could not be opened for writing");
     out_file << content_to_save;
     out_file.close();
 }
 
-static void report_failing_configuration(const std::string& exe,
-                                         const CLI::App& app,
-                                         CLI::Option_group* rt_default_opts,
+static void report_failing_configuration(const std::string&              exe,
+                                         const CLI::App&                 app,
+                                         CLI::Option_group*              rt_default_opts,
                                          const std::vector<std::string>& gtest_args)
 {
-    constexpr bool print_default_too = true;
-    std::string hipfft_test_options = app.config_to_str(!print_default_too);
+    constexpr bool print_default_too   = true;
+    std::string    hipfft_test_options = app.config_to_str(!print_default_too);
     // The above exports values for all options set by the user.
     // Default-initialized option values are not included: add those initialized
     // at runtime separately to ease reproducibility of reported failure(s)
-    for (auto* opt : rt_default_opts->get_options())
+    for(auto* opt : rt_default_opts->get_options())
     {
         // remove option from group if explicitly set to avoid
         // ill-constructed configuration files due to duplication(s)
-        if (*opt) rt_default_opts->remove_option(opt);
+        if(*opt)
+            rt_default_opts->remove_option(opt);
     }
     hipfft_test_options += rt_default_opts->config_to_str(print_default_too);
     std::string gtest_flagfile_content;
-    for (auto flag : gtest_args)
+    for(auto flag : gtest_args)
     {
-        if (flag.find(gtest_flagfile_opt) != std::string::npos)
+        if(flag.find(gtest_flagfile_opt) != std::string::npos)
         {
             // avoid generating a recursive inclusion of gtest flagfiles
             // if possible: copy content of file that was used instead
             try
             {
-                gtest_flagfile_content += get_file_content(flag.substr(gtest_flagfile_opt.length()));
+                gtest_flagfile_content
+                    += get_file_content(flag.substr(gtest_flagfile_opt.length()));
             }
-            catch (const std::exception& e)
+            catch(const std::exception& e)
             {
-                if (verbose)
+                if(verbose)
                 {
                     std::cout << "Resorting to use recursive flagfiles" << std::endl;
                 }
                 gtest_flagfile_content += flag;
             }
-        } else {
+        }
+        else
+        {
             gtest_flagfile_content += flag;
         }
-        if (gtest_flagfile_content.back() != '\n')
+        if(gtest_flagfile_content.back() != '\n')
         {
             gtest_flagfile_content += "\n";
         }
     }
     const std::string hipfft_test_config_file_to_save = config_file_to_save + hipfft_test_conf_ext;
-    const std::string gtest_config_file_to_save = config_file_to_save + gtest_conf_ext;
-    try {
+    const std::string gtest_config_file_to_save       = config_file_to_save + gtest_conf_ext;
+    try
+    {
         save_to_file(hipfft_test_options, hipfft_test_config_file_to_save);
         save_to_file(gtest_flagfile_content, gtest_config_file_to_save);
-        std::cout << "\nFailure(s) should be reproduced by \n\t"
-                    << exe;
-        if (!hipfft_test_config_file_to_save.empty())
+        std::cout << "\nFailure(s) should be reproduced by \n\t" << exe;
+        if(!hipfft_test_config_file_to_save.empty())
             std::cout << " " << hipfft_test_load_opt << " " << hipfft_test_config_file_to_save;
-        if (!gtest_flagfile_content.empty())
+        if(!gtest_flagfile_content.empty())
             std::cout << " " << gtest_flagfile_opt << gtest_config_file_to_save;
         std::cout << std::endl;
-    } catch (const std::exception& e)
+    }
+    catch(const std::exception& e)
     {
         std::cout << "\nFailed to save configuration to designated file(s).\n"
-                    << "\tException caught: "<< e.what() << "\n";
-        if (!hipfft_test_options.empty())
-            std::cout << "\nUsed hipfft-test options: \n"
-                        << hipfft_test_options;
-        if (!gtest_flagfile_content.empty())
-            std::cout << "\nUsed gtest flags: \n"
-                        << gtest_flagfile_content << "\n";
+                  << "\tException caught: " << e.what() << "\n";
+        if(!hipfft_test_options.empty())
+            std::cout << "\nUsed hipfft-test options: \n" << hipfft_test_options;
+        if(!gtest_flagfile_content.empty())
+            std::cout << "\nUsed gtest flags: \n" << gtest_flagfile_content << "\n";
         std::cout << std::endl;
     }
 }
@@ -393,10 +395,9 @@ int main(int argc, char* argv[])
         "      HP - hermitian planar\n"
         "\n"
         "Usage"};
-    auto* rt_default_opts =
-        app.add_option_group("Options with runtime-defined default values",
-                             "Option values are saved/reported in case of test "
-                             "failure (even if not set explicitly)");
+    auto* rt_default_opts = app.add_option_group("Options with runtime-defined default values",
+                                                 "Option values are saved/reported in case of test "
+                                                 "failure (even if not set explicitly)");
     // Override CLI11 help to print after later CLI11 options that are defined, and allow gtest's help
     app.set_help_flag("");
     CLI::Option* opt_help = app.add_flag("-h, --help", "Produces this help message");
@@ -442,12 +443,13 @@ int main(int argc, char* argv[])
         ->each([&](const std::string&) {
             if(mp_lib == fft_params::fft_mp_lib_none)
             {
-                throw CLI::ValidationError("--mp_launch requires an mp library (see mp_lib in --help)");
+                throw CLI::ValidationError(
+                    "--mp_launch requires an mp library (see mp_lib in --help)");
             }
         })
         ->needs("--mp_lib");
-    rt_default_opts->add_option(
-        "--seed", random_seed, "Random seed; if unset, use an actual random seed")
+    rt_default_opts
+        ->add_option("--seed", random_seed, "Random seed; if unset, use an actual random seed")
         ->default_val(default_seed_dev());
     app.add_flag("--smoketest", "Run a short (approx 5 minute) randomized selection of tests")
         ->each([&](const std::string&) {
@@ -456,7 +458,7 @@ int main(int argc, char* argv[])
             test_prob = 0.002;
         });
     // Token string to fully specify fft params for the manual test.
-    std::string test_token;
+    std::string  test_token;
     CLI::Option* opt_token
         = app.add_option("--token", test_token, "Test token name for manual test")->default_val("");
     app.set_config(hipfft_test_load_opt,
@@ -513,16 +515,17 @@ int main(int argc, char* argv[])
     non_token->add_option("--ooffset", manual_params.ooffset, "Output offset");
     non_token->add_option("--isize", manual_params.isize, "Logical size of input buffer");
     non_token->add_option("--osize", manual_params.osize, "Logical size of output buffer");
-    non_token->add_option("--scalefactor", manual_params.scale_factor, "Scale factor to apply to output");
+    non_token->add_option(
+        "--scalefactor", manual_params.scale_factor, "Scale factor to apply to output");
     // Default value is set in fft_params.h based on if device-side PRNG was enabled.
     non_token->add_option("-g, --inputGen",
-                   manual_params.igen,
-                   "Input data generation:\n0) PRNG sequence (device)\n"
-                   "1) PRNG sequence (host)\n"
-                   "2) linearly-spaced sequence (device)\n"
-                   "3) linearly-spaced sequence (host)");
-    CLI::Option* opt_version = app.add_flag("--version",
-        "Print queryable version information from the hipfft library's backend");
+                          manual_params.igen,
+                          "Input data generation:\n0) PRNG sequence (device)\n"
+                          "1) PRNG sequence (host)\n"
+                          "2) linearly-spaced sequence (device)\n"
+                          "3) linearly-spaced sequence (host)");
+    CLI::Option* opt_version = app.add_flag(
+        "--version", "Print queryable version information from the hipfft library's backend");
     // Try parsing initial args that will be used to configure tests
     // Allow extras to pass on gtest and hipFFT arguments without error
     app.allow_extras();
@@ -550,7 +553,7 @@ int main(int argc, char* argv[])
             return 1;
         }
     }
-    if (manual_params.length.empty())
+    if(manual_params.length.empty())
     {
         manual_params.length.push_back(8);
         // TODO: add random size?
@@ -580,18 +583,19 @@ int main(int argc, char* argv[])
     // arguments and sets argc and argv correctly;
     // Determine gtest args by identification of the argv set excluded by InitGoogleTest
     std::vector<std::string> gtest_args;
-    int argv_idx = 0;
-    for (; argv_idx < argc; argv_idx++)
-        gtest_args.push_back(argv[argv_idx]);   // all argv values are copied
-    ::testing::InitGoogleTest(&argc, argv);     // gtest args are removed
+    int                      argv_idx = 0;
+    for(; argv_idx < argc; argv_idx++)
+        gtest_args.push_back(argv[argv_idx]); // all argv values are copied
+    ::testing::InitGoogleTest(&argc, argv); // gtest args are removed
     // identify what was removed (assuming removals didn't change ordering)
-    auto arg = gtest_args.begin(); argv_idx = 0;
-    while (argv_idx < argc && arg != gtest_args.end())
+    auto arg = gtest_args.begin();
+    argv_idx = 0;
+    while(argv_idx < argc && arg != gtest_args.end())
     {
-        if (*arg == argv[argv_idx])
+        if(*arg == argv[argv_idx])
         {
             // argument not removed --> not specific to gtests
-            arg = gtest_args.erase(arg, arg+1);
+            arg = gtest_args.erase(arg, arg + 1);
             argv_idx++;
         }
         else
@@ -627,9 +631,10 @@ int main(int argc, char* argv[])
                    config_file_to_save,
                    "File(s) where the test options are to be written out, "
                    "if the test fails.\nUp to two files may be created, "
-                    "with extensions \"" + hipfft_test_conf_ext + "\" and/or \""
-                    + gtest_conf_ext +"\" added to this file name")
-                   ->default_val("saved_failed_test");
+                   "with extensions \""
+                       + hipfft_test_conf_ext + "\" and/or \"" + gtest_conf_ext
+                       + "\" added to this file name")
+        ->default_val("saved_failed_test");
 
     // Parse rest of args and catch any errors here
     try
@@ -647,10 +652,10 @@ int main(int argc, char* argv[])
         return EXIT_SUCCESS;
     }
     const int hipfft_version = get_hipfft_version();
-    if (*opt_version || verbose > 0)
+    if(*opt_version || verbose > 0)
     {
         std::cout << "hipFFT version: " << hipfft_version << std::endl;
-        if (*opt_version)
+        if(*opt_version)
         {
             return EXIT_SUCCESS;
         }
@@ -762,7 +767,7 @@ int main(int argc, char* argv[])
     std::cout << "double precision max l-inf epsilon: " << max_linf_eps_double << std::endl;
     std::cout << "double precision max l2 epsilon:     " << max_l2_eps_double << std::endl;
 
-    if (retval != EXIT_SUCCESS)
+    if(retval != EXIT_SUCCESS)
     {
         report_failing_configuration(argv[0], app, rt_default_opts, gtest_args);
     }

--- a/clients/tests/multi_device_test.cpp
+++ b/clients/tests/multi_device_test.cpp
@@ -33,7 +33,9 @@ static const std::vector<std::vector<size_t>> multi_gpu_sizes = {
     {128, 256},
     {64, 128, 256},
 };
-static const std::vector<size_t> multi_gpu_batch_range = {10, 1};
+static const std::vector<size_t>        multi_gpu_batch_range = {10, 1};
+static std::vector<std::vector<size_t>> ioffset_range_zero    = {{0, 0}};
+static std::vector<std::vector<size_t>> ooffset_range_zero    = {{0, 0}};
 
 enum SplitType
 {
@@ -69,15 +71,15 @@ std::vector<fft_params> param_generator_multi_gpu(const std::optional<SplitType>
         return {};
 
     static const std::vector<std::vector<size_t>> stride_range = {{1}};
-    auto params_complex = param_generator_complex(test_prob,
+    auto params_complex                                        = param_generator_complex(test_prob,
                                                   multi_gpu_sizes,
                                                   precision_range_sp_dp,
                                                   multi_gpu_batch_range,
                                                   stride_generator(stride_range),
                                                   stride_generator(stride_range),
-                                                  {{0, 0}},
-                                                  {{0, 0}},
-                                                  {fft_placement_inplace, fft_placement_notinplace},
+                                                  ioffset_range_zero,
+                                                  ooffset_range_zero,
+                                                  place_range,
                                                   false);
 
     auto params_real = param_generator_real(test_prob,
@@ -86,8 +88,8 @@ std::vector<fft_params> param_generator_multi_gpu(const std::optional<SplitType>
                                             multi_gpu_batch_range,
                                             stride_generator(stride_range),
                                             stride_generator(stride_range),
-                                            {{0, 0}},
-                                            {{0, 0}},
+                                            ioffset_range_zero,
+                                            ooffset_range_zero,
                                             {fft_placement_notinplace},
                                             false);
 

--- a/clients/tests/multi_device_test.cpp
+++ b/clients/tests/multi_device_test.cpp
@@ -33,6 +33,7 @@ static const std::vector<std::vector<size_t>> multi_gpu_sizes = {
     {128, 256},
     {64, 128, 256},
 };
+static const std::vector<size_t> multi_gpu_batch_range = {10, 1};
 
 enum SplitType
 {
@@ -71,7 +72,7 @@ std::vector<fft_params> param_generator_multi_gpu(const std::optional<SplitType>
     auto params_complex = param_generator_complex(test_prob,
                                                   multi_gpu_sizes,
                                                   precision_range_sp_dp,
-                                                  {1, 10},
+                                                  multi_gpu_batch_range,
                                                   stride_generator(stride_range),
                                                   stride_generator(stride_range),
                                                   {{0, 0}},
@@ -82,7 +83,7 @@ std::vector<fft_params> param_generator_multi_gpu(const std::optional<SplitType>
     auto params_real = param_generator_real(test_prob,
                                             multi_gpu_sizes,
                                             precision_range_sp_dp,
-                                            {1, 10},
+                                            multi_gpu_batch_range,
                                             stride_generator(stride_range),
                                             stride_generator(stride_range),
                                             {{0, 0}},

--- a/clients/tests/multi_device_test.cpp
+++ b/clients/tests/multi_device_test.cpp
@@ -68,7 +68,7 @@ std::vector<fft_params> param_generator_multi_gpu(const std::optional<SplitType>
         return {};
 
     static const std::vector<std::vector<size_t>> stride_range = {{1}};
-    auto params_complex                                        = param_generator_complex(test_prob,
+    auto params_complex = param_generator_complex(test_prob,
                                                   multi_gpu_sizes,
                                                   precision_range_sp_dp,
                                                   {1, 10},

--- a/shared/accuracy_test.h
+++ b/shared/accuracy_test.h
@@ -817,8 +817,8 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
             else
             {
                 ss << "hipMalloc failure for input buffer " << i << " size " << ibuffer_sizes[i]
-                   << "(" << bytes_to_GiB(ibuffer_sizes[i]) << " GiB)"
-                   << " with code " << hipError_to_string(hip_status);
+                   << "(" << bytes_to_GiB(ibuffer_sizes[i]) << " GiB)" << " with code "
+                   << hipError_to_string(hip_status);
             }
             ++n_hip_failures;
             if(skip_runtime_fails)
@@ -857,11 +857,12 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
             cpu_input.swap(last_cpu_fft_data.cpu_input);
             cpu_output.swap(last_cpu_fft_data.cpu_output);
             run_fftw = false;
-            if (params.scale_factor != 1.0) {
+            if(params.scale_factor != 1.0)
+            {
                 // cpu_output was stored *unscaled* in cache; scale it as
                 // required before using it for comparison purposes
                 // temporary lower run_callbacks flag
-                bool   no_run_callbacks = false;
+                bool no_run_callbacks = false;
                 std::swap(params.run_callbacks, no_run_callbacks);
                 apply_store_callback(params, cpu_output);
                 // restore params to what it was
@@ -1229,8 +1230,8 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
                 ++n_hip_failures;
                 std::stringstream ss;
                 ss << "hipMalloc failure for output buffer " << i << " size " << obuffer_sizes[i]
-                   << "(" << bytes_to_GiB(obuffer_sizes[i]) << " GiB)"
-                   << " with code " << hipError_to_string(hip_status);
+                   << "(" << bytes_to_GiB(obuffer_sizes[i]) << " GiB)" << " with code "
+                   << hipError_to_string(hip_status);
                 if(skip_runtime_fails)
                 {
                     throw ROCFFT_SKIP{ss.str()};
@@ -1401,12 +1402,14 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
     if(compare_output.valid())
         compare_output.get();
 
-    if(!store_to_cache) {
-        if (params.scale_factor != 1.0) {
+    if(!store_to_cache)
+    {
+        if(params.scale_factor != 1.0)
+        {
             // keep cpu_output *unscaled* in cache to make it reusable thereafter.
             // temporarily modify params to revert the effects of scale_factor
             double reciprocal_scale_factor = 1.0 / params.scale_factor;
-            bool   no_run_callbacks = false;
+            bool   no_run_callbacks        = false;
             std::swap(params.scale_factor, reciprocal_scale_factor);
             std::swap(params.run_callbacks, no_run_callbacks);
             apply_store_callback(params, cpu_output);
@@ -1485,14 +1488,15 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
         EXPECT_TRUE(diff.l_inf <= linf_cutoff)
             << "Linf test failed.  Linf:" << diff.l_inf
             << "\tnormalized Linf: " << diff.l_inf / cpu_output_norm.l_inf
-            << "\tcutoff: " << linf_cutoff << "\n" << params.str();
+            << "\tcutoff: " << linf_cutoff << "\n"
+            << params.str();
 
         EXPECT_TRUE(diff.l_2 / cpu_output_norm.l_2
                     <= sqrt(log2(total_length)) * type_epsilon(params.precision))
             << "L2 test failed. L2: " << diff.l_2
             << "\tnormalized L2: " << diff.l_2 / cpu_output_norm.l_2
-            << "\tepsilon: " << sqrt(log2(total_length)) * type_epsilon(params.precision)
-            << "\n" << params.str();
+            << "\tepsilon: " << sqrt(log2(total_length)) * type_epsilon(params.precision) << "\n"
+            << params.str();
     }
 
     if(round_trip && fftw_compare)

--- a/shared/accuracy_test.h
+++ b/shared/accuracy_test.h
@@ -857,6 +857,16 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
             cpu_input.swap(last_cpu_fft_data.cpu_input);
             cpu_output.swap(last_cpu_fft_data.cpu_output);
             run_fftw = false;
+            if (params.scale_factor != 1.0) {
+                // cpu_output was stored *unscaled* in cache; scale it as
+                // required before using it for comparison purposes
+                // temporary lower run_callbacks flag
+                bool   no_run_callbacks = false;
+                std::swap(params.run_callbacks, no_run_callbacks);
+                apply_store_callback(params, cpu_output);
+                // restore params to what it was
+                std::swap(params.run_callbacks, no_run_callbacks);
+            }
 
             store_to_cache = std::make_unique<StoreCPUDataToCache>(cpu_input, cpu_output);
 
@@ -1391,8 +1401,21 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
     if(compare_output.valid())
         compare_output.get();
 
-    if(!store_to_cache)
+    if(!store_to_cache) {
+        if (params.scale_factor != 1.0) {
+            // keep cpu_output *unscaled* in cache to make it reusable thereafter.
+            // temporarily modify params to revert the effects of scale_factor
+            double reciprocal_scale_factor = 1.0 / params.scale_factor;
+            bool   no_run_callbacks = false;
+            std::swap(params.scale_factor, reciprocal_scale_factor);
+            std::swap(params.run_callbacks, no_run_callbacks);
+            apply_store_callback(params, cpu_output);
+            // restore params to what it was
+            std::swap(params.scale_factor, reciprocal_scale_factor);
+            std::swap(params.run_callbacks, no_run_callbacks);
+        }
         store_to_cache = std::make_unique<StoreCPUDataToCache>(cpu_input, cpu_output);
+    }
 
     Tparams params_inverse;
 
@@ -1462,14 +1485,14 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
         EXPECT_TRUE(diff.l_inf <= linf_cutoff)
             << "Linf test failed.  Linf:" << diff.l_inf
             << "\tnormalized Linf: " << diff.l_inf / cpu_output_norm.l_inf
-            << "\tcutoff: " << linf_cutoff << params.str();
+            << "\tcutoff: " << linf_cutoff << "\n" << params.str();
 
         EXPECT_TRUE(diff.l_2 / cpu_output_norm.l_2
                     <= sqrt(log2(total_length)) * type_epsilon(params.precision))
             << "L2 test failed. L2: " << diff.l_2
             << "\tnormalized L2: " << diff.l_2 / cpu_output_norm.l_2
             << "\tepsilon: " << sqrt(log2(total_length)) * type_epsilon(params.precision)
-            << params.str();
+            << "\n" << params.str();
     }
 
     if(round_trip && fftw_compare)

--- a/shared/fft_params.h
+++ b/shared/fft_params.h
@@ -3085,7 +3085,7 @@ inline VectorNorms distance_1to2(const rocfft_complex<Tval>*             input,
     return {.l_2 = sqrt(l2), .l_inf = linf};
 }
 
-// Compute the L-inifnity and L-2 distance between two buffers of dimension length and
+// Compute the L-infinity and L-2 distance between two buffers of dimension length and
 // with types given by itype, otype, and precision.
 template <typename Tint1, typename Tint2, typename Tint3>
 inline VectorNorms distance(const std::vector<hostbuf>&             input,

--- a/shared/params_gen.h
+++ b/shared/params_gen.h
@@ -432,7 +432,7 @@ inline auto param_generator_real(const double                             base_p
                                  const bool planar,
                                  const bool run_callbacks = false)
 {
-    return param_generator_base(test_prob,
+    return param_generator_base(base_prob,
                                 trans_type_range_real,
                                 v_lengths,
                                 precision_range,

--- a/shared/params_gen.h
+++ b/shared/params_gen.h
@@ -27,6 +27,7 @@
 #include "fft_params.h"
 #include "test_params.h"
 
+const static std::vector<size_t> range_for_unbatched = {1};
 const static std::vector<size_t> batch_range = {2, 1};
 
 const static std::vector<fft_precision> precision_range_full
@@ -164,35 +165,130 @@ static std::vector<type_place_io_t>
     return ret;
 }
 
-struct stride_generator
+// basic struct template for various data generators, encapsulating a list of values
+// known at construction
+template <typename value_type>
+struct data_generator_base
 {
-    struct stride_dist
-    {
-        stride_dist(const std::vector<size_t>& s, size_t d)
-            : stride(s)
-            , dist(d)
-        {
-        }
-        std::vector<size_t> stride;
-        size_t              dist;
-    };
-
+protected:
+    const std::vector<value_type> value_list;
+public:
     // NOTE: allow for this ctor to be implicit, so it's less typing for a test writer
     //
     // cppcheck-suppress noExplicitConstructor
+    data_generator_base(const std::vector<value_type>& value_list_in)
+        : value_list(value_list_in)
+    {
+    }
+};
+
+// abstract struct template for generating data given some length(s) and a batch size
+template <typename value_type, typename ret_type = value_type>
+struct data_generator_from_lengths_and_batch : data_generator_base<value_type>
+{
+    data_generator_from_lengths_and_batch(const std::vector<value_type>& value_list_in)
+        : data_generator_base<value_type>(value_list_in)
+    {
+    }
+    virtual std::vector<ret_type> generate(const std::vector<size_t>& lengths, size_t batch) const = 0;
+};
+
+// abstract struct template for generating data given some length(s) only
+template <typename value_type, typename ret_type = value_type>
+struct data_generator_from_lengths : data_generator_base<value_type>
+{
+    data_generator_from_lengths(const std::vector<value_type>& value_list_in)
+        : data_generator_base<value_type>(value_list_in)
+    {
+    }
+    virtual std::vector<ret_type> generate(const std::vector<size_t>& lengths) const = 0;
+};
+
+struct stride_dist
+{
+    stride_dist(const std::vector<size_t>& s, size_t d)
+        : stride(s)
+        , dist(d)
+    {
+    }
+    const std::vector<size_t> stride;
+    const size_t              dist;
+};
+
+struct stride_generator : data_generator_from_lengths_and_batch<std::vector<size_t>, stride_dist>
+{
     stride_generator(const std::vector<std::vector<size_t>>& stride_list_in)
-        : stride_list(stride_list_in)
+        : data_generator_from_lengths_and_batch(stride_list_in)
     {
     }
     virtual std::vector<stride_dist> generate(const std::vector<size_t>& lengths,
                                               size_t                     batch) const
     {
+        // default behavior: return the encapsulated stride data with 0 (default) distance
+        // (lengths and batch unused in this case)
         std::vector<stride_dist> ret;
-        for(const auto& s : stride_list)
+        for(const auto& s : value_list)
             ret.emplace_back(s, 0);
         return ret;
     }
-    std::vector<std::vector<size_t>> stride_list;
+};
+
+struct batch_generator : data_generator_from_lengths<size_t>
+{
+    batch_generator(const std::vector<size_t>& batch_list_in)
+        : data_generator_from_lengths(batch_list_in)
+    {
+    }
+    virtual std::vector<size_t> generate(const std::vector<size_t>& lengths) const
+    {
+        // default behavior: return the encapsulated batch data
+        // (lengths unused in this case)
+        return value_list;
+    }
+};
+
+struct inner_batch_generator : public batch_generator
+{
+    inner_batch_generator() :
+        batch_generator({1 /* dummy, value_list is irrelevant in this case */})
+    {
+    };
+
+    std::vector<size_t> generate(const std::vector<size_t>& lengths) const override
+    {
+        assert(lengths.size() > 0);
+        // batch size set to the problem's last lengths ("fastest" dimension)
+        std::vector<size_t> ret(1, lengths.back());
+        return ret;
+    }
+};
+
+template<size_t dim = 1, std::enable_if_t<(dim > 0), bool> = true>
+struct inner_batch_stride_generator : public stride_generator
+{
+    inner_batch_stride_generator() :
+        stride_generator({{1 /* dummy, value_list is irrelevant in this case */}})
+    {
+    };
+
+    std::vector<stride_dist> generate(const std::vector<size_t>& lengths,
+                                      size_t                     batch) const override
+    {
+        assert(lengths.size() == dim);
+        // only positive strides assumed in here
+        std::vector<size_t> strides;
+        auto cur_stride = std::accumulate(lengths.begin() + 1,
+                                          lengths.end(),
+                                          batch,
+                                          std::multiplies<size_t>());
+        for (auto length : lengths) {
+            strides.emplace_back(cur_stride);
+            cur_stride /= length;
+        }
+        assert(cur_stride == 1); // := distance for "inner_batch" layout
+        std::vector<stride_dist> ret(1, {strides, cur_stride});
+        return ret;
+    }
 };
 
 // Generate strides such that batch is essentially the innermost dimension
@@ -228,6 +324,8 @@ struct stride_generator_3D_inner_batch : public stride_generator
                                       size_t                     batch) const override
     {
         std::vector<stride_dist> ret = stride_generator::generate(lengths, batch);
+        // Note: the above call makes this struct behave slightly differently from
+        // inner_batch_stride_generator<3>...
         std::vector<size_t> strides{lengths[1] * lengths[2] * batch, lengths[2] * batch, batch};
         ret.emplace_back(strides, 1);
         return ret;
@@ -240,7 +338,7 @@ inline auto param_generator_base(const double                             base_p
                                  const std::vector<fft_transform_type>&   type_range,
                                  const std::vector<std::vector<size_t>>&  v_lengths,
                                  const std::vector<fft_precision>&        precisions,
-                                 const std::vector<size_t>&               batch_range,
+                                 const batch_generator&                   batch_range,
                                  decltype(generate_types)                 types_generator,
                                  const stride_generator&                  istride,
                                  const stride_generator&                  ostride,
@@ -272,7 +370,7 @@ inline auto param_generator_base(const double                             base_p
             {
                 for(const auto precision : precisions)
                 {
-                    for(const auto batch : batch_range)
+                    for(const auto batch : batch_range.generate(lengths))
                     {
                         for(const auto& types :
                             types_generator(transform_type, place_range, planar))
@@ -362,7 +460,7 @@ inline auto param_generator_base(const double                             base_p
 inline auto param_generator(const double                             base_prob,
                             const std::vector<std::vector<size_t>>&  v_lengths,
                             const std::vector<fft_precision>&        precision_range,
-                            const std::vector<size_t>&               batch_range,
+                            const batch_generator&                   batch_range,
                             const stride_generator&                  istride,
                             const stride_generator&                  ostride,
                             const std::vector<std::vector<size_t>>&  ioffset_range,
@@ -392,7 +490,7 @@ inline auto param_generator(const double                             base_prob,
 inline auto param_generator_complex(const double                             base_prob,
                                     const std::vector<std::vector<size_t>>&  v_lengths,
                                     const std::vector<fft_precision>&        precision_range,
-                                    const std::vector<size_t>&               batch_range,
+                                    const batch_generator&                   batch_range,
                                     const stride_generator&                  istride,
                                     const stride_generator&                  ostride,
                                     const std::vector<std::vector<size_t>>&  ioffset_range,
@@ -422,7 +520,7 @@ inline auto param_generator_complex(const double                             bas
 inline auto param_generator_real(const double                             base_prob,
                                  const std::vector<std::vector<size_t>>&  v_lengths,
                                  const std::vector<fft_precision>&        precision_range,
-                                 const std::vector<size_t>&               batch_range,
+                                 const batch_generator&                   batch_range,
                                  const stride_generator&                  istride,
                                  const stride_generator&                  ostride,
                                  const std::vector<std::vector<size_t>>&  ioffset_range,

--- a/shared/params_gen.h
+++ b/shared/params_gen.h
@@ -28,7 +28,7 @@
 #include "test_params.h"
 
 const static std::vector<size_t> range_for_unbatched = {1};
-const static std::vector<size_t> batch_range = {2, 1};
+const static std::vector<size_t> batch_range         = {2, 1};
 
 const static std::vector<fft_precision> precision_range_full
     = {fft_precision_double, fft_precision_single, fft_precision_half};
@@ -172,6 +172,7 @@ struct data_generator_base
 {
 protected:
     const std::vector<value_type> value_list;
+
 public:
     // NOTE: allow for this ctor to be implicit, so it's less typing for a test writer
     //
@@ -190,7 +191,8 @@ struct data_generator_from_lengths_and_batch : data_generator_base<value_type>
         : data_generator_base<value_type>(value_list_in)
     {
     }
-    virtual std::vector<ret_type> generate(const std::vector<size_t>& lengths, size_t batch) const = 0;
+    virtual std::vector<ret_type> generate(const std::vector<size_t>& lengths, size_t batch) const
+        = 0;
 };
 
 // abstract struct template for generating data given some length(s) only
@@ -249,10 +251,8 @@ struct batch_generator : data_generator_from_lengths<size_t>
 
 struct inner_batch_generator : public batch_generator
 {
-    inner_batch_generator() :
-        batch_generator({1 /* dummy, value_list is irrelevant in this case */})
-    {
-    };
+    inner_batch_generator()
+        : batch_generator({1 /* dummy, value_list is irrelevant in this case */}){};
 
     std::vector<size_t> generate(const std::vector<size_t>& lengths) const override
     {
@@ -263,13 +263,11 @@ struct inner_batch_generator : public batch_generator
     }
 };
 
-template<size_t dim = 1, std::enable_if_t<(dim > 0), bool> = true>
+template <size_t dim = 1, std::enable_if_t<(dim > 0), bool> = true>
 struct inner_batch_stride_generator : public stride_generator
 {
-    inner_batch_stride_generator() :
-        stride_generator({{1 /* dummy, value_list is irrelevant in this case */}})
-    {
-    };
+    inner_batch_stride_generator()
+        : stride_generator({{1 /* dummy, value_list is irrelevant in this case */}}){};
 
     std::vector<stride_dist> generate(const std::vector<size_t>& lengths,
                                       size_t                     batch) const override
@@ -277,11 +275,10 @@ struct inner_batch_stride_generator : public stride_generator
         assert(lengths.size() == dim);
         // only positive strides assumed in here
         std::vector<size_t> strides;
-        auto cur_stride = std::accumulate(lengths.begin() + 1,
-                                          lengths.end(),
-                                          batch,
-                                          std::multiplies<size_t>());
-        for (auto length : lengths) {
+        auto                cur_stride
+            = std::accumulate(lengths.begin() + 1, lengths.end(), batch, std::multiplies<size_t>());
+        for(auto length : lengths)
+        {
             strides.emplace_back(cur_stride);
             cur_stride /= length;
         }

--- a/shared/work_queue.h
+++ b/shared/work_queue.h
@@ -36,7 +36,7 @@ struct WorkQueue
     {
         std::unique_lock<std::mutex> lock(queueMutex);
         while(items.empty())
-            emptyWait.wait(lock);
+            emptyWait.wait(lock); // lock was acquired so possible deadlock here conceptually?
         _WorkItem item(items.front());
         items.pop();
         return item;


### PR DESCRIPTION
This work grew a little beyond what I intended to submit as a single PR: if it helps the reviews, I can split this in 3 PRs covering the following points (by decreasing order of importance).

Resolved issues
==========
This PR does address some (unknown) issues in the test base, namely:
- some test probability factors are left uninitialized (_e.g._, `real_prob_factor`), possibly resulting in never-triggered tests;
- `random_seed` is never initialized if the `--seed` option is not used;
- cached results used in accuracy test ignore possible differences in the `scale_factor` used when generating them;
- there are possible differences between what is tested "manually" or by the parameterized "accuracy_test" suite for one given test token (particularly if `multiGPU > 1`).

Suggested improvements
=================
In addition, some additional changes are suggested to:
- reduce compilation time by addressing some inconsistencies in CMake files regarding the usage of `{AMD}GPU_TARGETS`;
- alleviate duplications to ease maintenance/readability in places;
- remove unused variables or use them where their usage seemed to be intended (but omitted);
- modified some "rocfft" references to "hipfft" where it seemed relevant/appropriate.

New feature
========
I'm suggesting a new feature for `hipfft-test`: in case of failure, the program writes up to 2 configuration files (one for the hipfft-test options, another one for the gtest flags) which should suffice to reproduce the same run thereafter.

Note
-----
This PR brings some (very little) gains in test coverage (from addressing nonzero probability factors and querying hipfft version in main). 