### PR TITLE
Reconcile logic for {AMD}GPU_TARGETS between hipfft and dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,12 +132,6 @@ endif()
 
 # Dependencies
 include(cmake/dependencies.cmake)
-# Note: the above does 'find_package(rocfft REQUIRED)' which eventually
-# includes /opt/rocm/lib/cmake/hip/hip-config-amd.cmake on AMD platforms.
-# The latter does set GPU_TARGETS (cached) to
-# - AMDGPU_TARGETS if it is used (printing a deprecation warning);
-# - the (list of) GPU device(s) automatically detected on the platform if
-#   neither GPU_TARGETS nor AMDGPU_TARGETS is used.
 
 if (BUILD_WITH_COMPILER STREQUAL "HIP-NVCC" )
   set (BUILD_WITH_LIB "CUDA")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,12 @@ endif()
 
 # Dependencies
 include(cmake/dependencies.cmake)
+# Note: the above does 'find_package(rocfft REQUIRED)' which eventually
+# includes /opt/rocm/lib/cmake/hip/hip-config-amd.cmake on AMD platforms.
+# The latter does set GPU_TARGETS (cached) to
+# - AMDGPU_TARGETS if it is used (printing a deprecation warning);
+# - the (list of) GPU device(s) automatically detected on the platform if
+#   neither GPU_TARGETS nor AMDGPU_TARGETS is used.
 
 if (BUILD_WITH_COMPILER STREQUAL "HIP-NVCC" )
   set (BUILD_WITH_LIB "CUDA")
@@ -164,14 +170,8 @@ if (BUILD_WITH_COMPILER STREQUAL "HIP-NVCC" )
   set( WARNING_FLAGS ${NVCC_WARNING_FLAGS} )
 
 else()
-  # Define GPU targets
-  if(AMDGPU_TARGETS AND NOT GPU_TARGETS)
-    message( DEPRECATION "AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS." )
-  endif()
-  set(AMDGPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING "Target default GPUs if AMDGPU_TARGETS is not defined. (Deprecated, prefer GPU_TARGETS)")
-  rocm_check_target_ids(AMDGPU_TARGETS TARGETS "${AMDGPU_TARGETS}")
-  # Don't force, users should be able to override GPU_TARGETS at the command line if desired
-  set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for")
+  # Check support for the GPU target(s)
+  rocm_check_target_ids(GPU_TARGETS TARGETS "${GPU_TARGETS}")
   if( BUILD_WITH_COMPILER STREQUAL "HIP-CLANG" )
     set( HIP_PLATFORM "amd" )
     set( HIP_COMPILER "clang" )

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -112,7 +112,7 @@ foreach( target ${TEST_TARGETS} )
       hip::host
       hip::device
     )
-    foreach( gpu_target ${AMDGPU_TARGETS} )
+    foreach( gpu_target ${GPU_TARGETS} )
       target_compile_options( ${target} PRIVATE --offload-arch=${gpu_target} )
     endforeach()
 


### PR DESCRIPTION
- The project's current cmake logic for handling the deprecated `AMDGPU_TARGETS` is bypassed by a rocm dependency included earlier, in my understanding (making it irrelevant/inaccessible);
- `AMDGPU_TARGETS` is still used in the "test" client despite being deprecated (responsible for quite a confusing behavior if `GPU_TARGETS` was actually used instead, as the deprecation warning recommends)