### PR TITLE
Some fixes and other minor changes to hipfft-test

### DIFF
--- a/clients/tests/accuracy_test_1D.cpp
+++ b/clients/tests/accuracy_test_1D.cpp
@@ -319,29 +319,22 @@ INSTANTIATE_TEST_SUITE_P(DISABLED_offset_mix_1D,
 
 // small 1D sizes just need to make sure our factorization isn't
 // completely broken, so we just check simple C2C outplace interleaved
-INSTANTIATE_TEST_SUITE_P(small_1D,
-                         accuracy_test,
-                         ::testing::ValuesIn(param_generator_base(
-                             test_prob,
-                             {fft_transform_type_complex_forward},
-                             generate_lengths({small_1D_sizes()}),
-                             {fft_precision_single},
-                             {1},
-                             [](fft_transform_type                       t,
-                                const std::vector<fft_result_placement>& place_range,
-                                const bool                               planar) {
-                                 return std::vector<type_place_io_t>{
-                                     std::make_tuple(t,
-                                                     place_range[0],
-                                                     fft_array_type_complex_interleaved,
-                                                     fft_array_type_complex_interleaved)};
-                             },
-                             stride_range,
-                             stride_range,
-                             ioffset_range_zero,
-                             ooffset_range_zero,
-                             {fft_placement_notinplace})),
-                         accuracy_test::TestName);
+INSTANTIATE_TEST_SUITE_P(
+    small_1D,
+    accuracy_test,
+    ::testing::ValuesIn(param_generator_base(test_prob,
+                                             {fft_transform_type_complex_forward},
+                                             generate_lengths({small_1D_sizes()}),
+                                             {fft_precision_single},
+                                             {1},
+                                             generate_types,
+                                             stride_range,
+                                             stride_range,
+                                             ioffset_range_zero,
+                                             ooffset_range_zero,
+                                             {fft_placement_notinplace},
+                                             false /* planar */)),
+    accuracy_test::TestName);
 
 // NB:
 // We have known non-unit strides issues for 1D:
@@ -352,7 +345,7 @@ INSTANTIATE_TEST_SUITE_P(small_1D,
 // main tests.
 //
 // The below test covers non-unit strides, pow of 2, middle sizes, which has SBCC/SBRC kernels
-// invloved.
+// involved.
 const static std::vector<size_t>              pow2_range_for_stride      = {4096, 8192, 524288};
 const static std::vector<size_t>              pow2_range_for_stride_half = {4096, 8192};
 const static std::vector<std::vector<size_t>> stride_range_for_pow2      = {{2}, {3}};
@@ -364,7 +357,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn(param_generator_complex(test_prob,
                                                 generate_lengths({pow2_range_for_stride}),
                                                 precision_range_sp_dp,
-                                                batch_range_1D,
+                                                batch_range_for_stride,
                                                 stride_range_for_pow2,
                                                 stride_range_for_pow2,
                                                 ioffset_range_zero,
@@ -380,7 +373,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn(param_generator_real(test_prob,
                                              generate_lengths({pow2_range_for_stride}),
                                              precision_range_sp_dp,
-                                             batch_range_1D,
+                                             batch_range_for_stride,
                                              stride_range_for_pow2,
                                              stride_range_for_pow2,
                                              ioffset_range_zero,
@@ -396,7 +389,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn(param_generator_real(test_prob,
                                              generate_lengths({pow2_range_for_stride_half}),
                                              {fft_precision_half},
-                                             batch_range_1D,
+                                             batch_range_for_stride,
                                              stride_range_for_pow2,
                                              stride_range_for_pow2,
                                              ioffset_range_zero,

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -459,7 +459,11 @@ int main(int argc, char* argv[])
     // suites).
     // set any "unset" parameters of manual_params before initiating gtests
     // (makes the token reported by gtest less ambiguous)
-    manual_params.validate();
+    if(!*opt_token)
+    {
+        manual_params.validate();
+    }
+
     // NB: If we initialize gtest first, then it removes all of its own command-line
     // arguments and sets argc and argv correctly;
     ::testing::InitGoogleTest(&argc, argv); // gtest args are removed

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -46,15 +46,11 @@
 // Control output verbosity:
 int verbose;
 
-// Run a short (~5 min) test suite by setting test_prob to an appropriate value
-bool smoketest = false;
-
 // User-defined random seed
-size_t random_seed;
+size_t             random_seed;
+std::random_device default_seed_dev;
 // Overall probability of running conventional tests
 double test_prob;
-// Probability of running tests from the emulation suite
-double emulation_prob;
 // Modifier for probability of running tests with complex interleaved data
 double complex_interleaved_prob_factor;
 // Modifier for probability of running tests with real data
@@ -104,7 +100,7 @@ last_cpu_fft_cache last_cpu_fft_data;
 fft_params::fft_mp_lib mp_lib = fft_params::fft_mp_lib_none;
 // Number of multi-process ranks to launch
 int mp_ranks = 1;
-// Multi-process launch command (e.g. mpirun --np 4 /path/to/rocfft_mpi_worker)
+// Multi-process launch command (e.g. mpirun --np 4 /path/to/hipfft_mpi_worker)
 std::string mp_launch;
 
 void init_gtest_flags()
@@ -176,6 +172,10 @@ void precompile_test_kernels(const std::string& precompile_file)
             // only care about accuracy tests
             if(name.find("vs_fftw/") != std::string::npos)
             {
+                // [possible TODO] move above check to nesting loop's scope as a
+                // check on the test suite's name (i.e., if it includes "accuracy_test").
+                // That would allow other (hypothetical) accuracy test instances than
+                // "vs_fftw/" to be considered as well...
                 name.erase(0, 8);
 
                 // change batch to 1, so we don't waste time creating
@@ -250,6 +250,18 @@ void precompile_test_kernels(const std::string& precompile_file)
               << " ms\n";
 }
 
+// helper function including some testing
+static inline int get_hipfft_version()
+{
+    // TODO: this segfaults, fix in hipFFT and enable here
+    // EXPECT_EQ(hipfftGetVersion(nullptr), HIPFFT_INVALID_VALUE);
+    int v;
+    EXPECT_EQ(hipfftGetVersion(&v), HIPFFT_SUCCESS);
+    // maybe possible to verify v (e.g. by comparison with compile-time-defined
+    // values defined in some backend's header)?
+    return v;
+}
+
 int main(int argc, char* argv[])
 {
     CLI::App app{
@@ -271,7 +283,6 @@ int main(int argc, char* argv[])
         "      HP - hermitian planar\n"
         "\n"
         "Usage"};
-
     // Override CLI11 help to print after later CLI11 options that are defined, and allow gtest's help
     app.set_help_flag("");
     CLI::Option* opt_help = app.add_flag("-h, --help", "Produces this help message");
@@ -280,12 +291,22 @@ int main(int argc, char* argv[])
     app.add_option("--test_prob", test_prob, "Probability of running individual tests")
         ->default_val(1.0)
         ->check(CLI::Range(0.0, 1.0));
+    app.add_option("--real_prob",
+                   real_prob_factor,
+                   "Probability multiplier for running individual real/complex transforms")
+        ->default_val(1.0)
+        ->check(CLI::PositiveNumber);
+    app.add_option("--planar_prob",
+                   complex_planar_prob_factor,
+                   "Probability multiplier for running individual planar transforms")
+        ->default_val(0.1)
+        ->check(CLI::PositiveNumber);
     app.add_option(
            "--complex_interleaved_prob_factor",
            complex_interleaved_prob_factor,
            "Probability multiplier for running individual transforms with complex interleaved data")
         ->default_val(1)
-        ->check(CLI::NonNegativeNumber);
+        ->check(CLI::PositiveNumber);
     app.add_option("--callback_prob",
                    callback_prob_factor,
                    "Probability multiplier for running individual callback transforms")
@@ -302,71 +323,38 @@ int main(int argc, char* argv[])
     app.add_option("--mp_launch",
                    mp_launch,
                    "Command line prefix to launch multi-process transforms, e.g. \"mpirun --np 4 "
-                   "/path/to/rocfft_mpi_worker\"")
+                   "/path/to/hipfft_mpi_worker\"")
         ->default_val("")
         ->each([&](const std::string&) {
             if(mp_lib == fft_params::fft_mp_lib_none)
             {
-                std::cout << "--mp_launch requires an mp library (see mp_lib in --help).\n";
-                std::exit(-1);
+                throw CLI::ValidationError(
+                    "--mp_launch requires an mp library (see mp_lib in --help)");
             }
         })
         ->needs("--mp_lib");
-    // FIXME: Seed has no use currently
-    // CLI::Option* opt_seed =
-    app.add_option("--seed", random_seed, "Random seed; if unset, use an actual random seed");
+    app.add_option("--seed", random_seed, "Random seed; if unset, use an actual random seed")
+        ->default_val(default_seed_dev());
     app.add_flag("--smoketest", "Run a short (approx 5 minute) randomized selection of tests")
         ->each([&](const std::string&) {
             // The objective is to have an test that takes about 5 minutes, so just set the probability
             // per test to a small value to achieve this result.
             test_prob = 0.002;
         });
-
-    // Try parsing initial args that will be used to configure tests
-    // Allow extras to pass on gtest and hipFFT arguments without error
-    app.allow_extras();
-    try
-    {
-        app.parse(argc, argv);
-    }
-    catch(const CLI::ParseError& e)
-    {
-        return app.exit(e);
-    }
-
-    // NB: If we initialize gtest first, then it removes all of its own command-line
-    // arguments and sets argc and argv correctly;
-    ::testing::InitGoogleTest(&argc, argv);
-
-    // Filename for fftw and fftwf wisdom.
-    std::string fftw_wisdom_filename;
-
     // Token string to fully specify fft params for the manual test.
-    std::string test_token;
-
-    // Filename for precompiled kernels to be written to
-    std::string precompile_file;
-
-    // Declare the supported options. Some option pointers are declared to track passed opts.
-    app.add_flag("--callback", "Inject load/store callbacks")->each([&](const std::string&) {
-        manual_params.run_callbacks = true;
-    });
-    // app.add_flag("--version", "Print queryable version information from the rocfft library")
-    //     ->each([](const std::string&) {
-    //         rocfft_setup();
-    //         char v[256];
-    //         rocfft_get_version_string(v, 256);
-    //         std::cout << "rocFFT version: " << v << std::endl;
-    //         return EXIT_SUCCESS;
-    //     });
+    std::string  test_token;
     CLI::Option* opt_token
         = app.add_option("--token", test_token, "Test token name for manual test")->default_val("");
     // Group together options that conflict with --token
     auto* non_token = app.add_option_group("Token Conflict", "Options excluded by --token");
+    non_token->excludes(opt_token);
+    // Declare the supported options. Some option pointers are declared to track passed opts.
+    non_token->add_flag("--callback", "Inject load/store callbacks")->each([&](const std::string&) {
+        manual_params.run_callbacks = true;
+    });
     non_token
         ->add_flag("--double", "Double precision transform (deprecated: use --precision double)")
         ->each([&](const std::string&) { manual_params.precision = fft_precision_double; });
-    non_token->excludes(opt_token);
     non_token
         ->add_option("-t, --transformType",
                      manual_params.transform_type,
@@ -406,35 +394,22 @@ int main(int argc, char* argv[])
         ->default_val(0);
     non_token->add_option("--ioffset", manual_params.ioffset, "Input offset");
     non_token->add_option("--ooffset", manual_params.ooffset, "Output offset");
-    app.add_option("--isize", manual_params.isize, "Logical size of input buffer");
-    app.add_option("--osize", manual_params.osize, "Logical size of output buffer");
-    app.add_option("--R", ramgb, "RAM limit in GiB for tests")
-        ->default_val(host_memory::singleton().get_total_gbytes());
-    app.add_option("--V", vramgb, "VRAM limit in GiB for tests")->default_val(0);
-    app.add_option("--half_epsilon", half_epsilon)->default_val(9.77e-4);
-    app.add_option("--single_epsilon", single_epsilon)->default_val(3.75e-5);
-    app.add_option("--double_epsilon", double_epsilon)->default_val(1e-15);
-    app.add_option("--skip_runtime_fails",
-                   skip_runtime_fails,
-                   "Skip the test if there is a runtime failure")
-        ->default_val(true);
-    app.add_option("-w, --wise", use_fftw_wisdom, "Use FFTW wisdom");
-    app.add_option("-W, --wisdomfile", fftw_wisdom_filename, "FFTW3 wisdom filename")
-        ->default_val("wisdom3.txt");
-    app.add_option("--scalefactor", manual_params.scale_factor, "Scale factor to apply to output");
-    app.add_option("--precompile",
-                   precompile_file,
-                   "Precompile kernels to a file for all test cases before running tests")
-        ->default_val("");
+    non_token->add_option("--isize", manual_params.isize, "Logical size of input buffer");
+    non_token->add_option("--osize", manual_params.osize, "Logical size of output buffer");
+    non_token->add_option(
+        "--scalefactor", manual_params.scale_factor, "Scale factor to apply to output");
     // Default value is set in fft_params.h based on if device-side PRNG was enabled.
-    app.add_option("-g, --inputGen",
-                   manual_params.igen,
-                   "Input data generation:\n0) PRNG sequence (device)\n"
-                   "1) PRNG sequence (host)\n"
-                   "2) linearly-spaced sequence (device)\n"
-                   "3) linearly-spaced sequence (host)");
-
-    // Parse rest of args and catch any errors here
+    non_token->add_option("-g, --inputGen",
+                          manual_params.igen,
+                          "Input data generation:\n0) PRNG sequence (device)\n"
+                          "1) PRNG sequence (host)\n"
+                          "2) linearly-spaced sequence (device)\n"
+                          "3) linearly-spaced sequence (host)");
+    CLI::Option* opt_version = app.add_flag(
+        "--version", "Print queryable version information from the hipfft library's backend");
+    // Try parsing initial args that will be used to configure tests
+    // Allow extras to pass on gtest and hipFFT arguments without error
+    app.allow_extras();
     try
     {
         app.parse(argc, argv);
@@ -444,26 +419,21 @@ int main(int argc, char* argv[])
         return app.exit(e);
     }
 
-    if(*opt_help)
+    if(!test_token.empty())
     {
-        std::cout << app.help() << "\n";
-        return EXIT_SUCCESS;
+        std::cout << "Reading fft params from token:\n" << test_token << std::endl;
+
+        try
+        {
+            manual_params.from_token(test_token);
+            std::cout << "manual_params.token() = " << manual_params.token() << std::endl;
+        }
+        catch(...)
+        {
+            std::cout << "Unable to parse token." << std::endl;
+            return 1;
+        }
     }
-
-    // Ensure there are no leftover options used by neither gtest nor CLI11
-    std::vector<std::string> remaining_args = app.remaining();
-    if(!remaining_args.empty())
-    {
-        std::cout << "Unrecognised option(s) found:\n  ";
-        for(auto i : app.remaining())
-            std::cout << i << " ";
-        std::cout << "\nRun with --help for more information.\n";
-        return EXIT_FAILURE;
-    }
-
-    std::cout << "half epsilon: " << half_epsilon << "\tsingle epsilon: " << single_epsilon
-              << "\tdouble epsilon: " << double_epsilon << std::endl;
-
     if(manual_params.length.empty())
     {
         manual_params.length.push_back(8);
@@ -482,6 +452,81 @@ int main(int argc, char* argv[])
         // TODO: add random size?
     }
 
+    // User-settable options defining the values of all the actual test parameters
+    // (e.g., probability factors and value of manual_params) must be handled
+    // before invoking ::testing::InitGoogleTest as it triggers evaluation of said
+    // parameters (e.g., args of "::testing::Values{In}" in instantiations of test
+    // suites).
+    // set any "unset" parameters of manual_params before initiating gtests
+    // (makes the token reported by gtest less ambiguous)
+    manual_params.validate();
+    // NB: If we initialize gtest first, then it removes all of its own command-line
+    // arguments and sets argc and argv correctly;
+    ::testing::InitGoogleTest(&argc, argv); // gtest args are removed
+    // Filename for fftw and fftwf wisdom.
+    std::string fftw_wisdom_filename;
+
+    // Filename for precompiled kernels to be written to
+    std::string precompile_file;
+
+    app.add_option("--R", ramgb, "RAM limit in GiB for tests")
+        ->default_val(host_memory::singleton().get_total_gbytes());
+    app.add_option("--V", vramgb, "VRAM limit in GiB for tests")->default_val(0);
+    app.add_option("--half_epsilon", half_epsilon)->default_val(9.77e-4);
+    app.add_option("--single_epsilon", single_epsilon)->default_val(3.75e-5);
+    app.add_option("--double_epsilon", double_epsilon)->default_val(1e-15);
+    app.add_option("--skip_runtime_fails",
+                   skip_runtime_fails,
+                   "Skip the test if there is a runtime failure")
+        ->default_val(true);
+    app.add_option("-w, --wise", use_fftw_wisdom, "Use FFTW wisdom");
+    app.add_option("-W, --wisdomfile", fftw_wisdom_filename, "FFTW3 wisdom filename")
+        ->default_val("wisdom3.txt");
+    app.add_option("--precompile",
+                   precompile_file,
+                   "Precompile kernels to a file for all test cases before running tests")
+        ->default_val("");
+
+    // Parse rest of args and catch any errors here
+    try
+    {
+        app.parse(argc, argv);
+    }
+    catch(const CLI::ParseError& e)
+    {
+        return app.exit(e);
+    }
+
+    if(*opt_help)
+    {
+        std::cout << app.help() << "\n";
+        return EXIT_SUCCESS;
+    }
+    const int hipfft_version = get_hipfft_version();
+    if(*opt_version || verbose > 0)
+    {
+        std::cout << "hipFFT version: " << hipfft_version << std::endl;
+        if(*opt_version)
+        {
+            return EXIT_SUCCESS;
+        }
+    }
+
+    // Ensure there are no leftover options used by neither gtest nor CLI11
+    std::vector<std::string> remaining_args = app.remaining();
+    if(!remaining_args.empty())
+    {
+        std::cout << "Unrecognised option(s) found:\n  ";
+        for(auto i : app.remaining())
+            std::cout << i << " ";
+        std::cout << "\nRun with --help for more information.\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Using random_seed = " << random_seed << std::endl;
+    std::cout << "half epsilon: " << half_epsilon << "\tsingle epsilon: " << single_epsilon
+              << "\tdouble epsilon: " << double_epsilon << std::endl;
+
     // if precompiling, tell rocFFT to use the specified cache file
     // to write kernels to
     //
@@ -493,11 +538,6 @@ int main(int argc, char* argv[])
         env_precompile = std::make_unique<EnvironmentSetTemp>("ROCFFT_RTC_CACHE_PATH",
                                                               precompile_file.c_str());
     }
-
-    // rocfft_setup();
-    // char v[256];
-    // rocfft_get_version_string(v, 256);
-    // std::cout << "rocFFT version: " << v << std::endl;
 
 #ifdef FFTW_MULTITHREAD
     fftw_init_threads();
@@ -555,21 +595,6 @@ int main(int argc, char* argv[])
         fftwf_import_wisdom_from_string(fftwf_wisdom.c_str());
     }
 
-    if(!test_token.empty())
-    {
-        std::cout << "Reading fft params from token:\n" << test_token << std::endl;
-
-        try
-        {
-            manual_params.from_token(test_token);
-        }
-        catch(...)
-        {
-            std::cout << "Unable to parse token." << std::endl;
-            return 1;
-        }
-    }
-
     if(!precompile_file.empty())
         precompile_test_kernels(precompile_file);
 
@@ -593,38 +618,12 @@ int main(int argc, char* argv[])
     std::cout << "double precision max l-inf epsilon: " << max_linf_eps_double << std::endl;
     std::cout << "double precision max l2 epsilon:     " << max_l2_eps_double << std::endl;
 
-    // rocfft_cleanup();
     return retval;
 }
 
-TEST(manual, vs_fftw)
-{
-    // Run an individual test using the provided command-line parameters.
-
-    std::cout << "Manual test:" << std::endl;
-
-    manual_params.validate();
-
-    std::cout << "Token: " << manual_params.token() << std::endl;
-
-    hipfft_params params(manual_params);
-
-    try
-    {
-        fft_vs_reference(params, false);
-    }
-    catch(HOSTBUF_MEM_USAGE& e)
-    {
-        // explicitly clear test cache
-        last_cpu_fft_data = last_cpu_fft_cache();
-        GTEST_SKIP() << e.msg;
-    }
-    catch(ROCFFT_SKIP& e)
-    {
-        GTEST_SKIP() << e.msg;
-    }
-    catch(ROCFFT_FAIL& e)
-    {
-        GTEST_FAIL() << e.msg;
-    }
-}
+// instantiation of the paramameterized accuracy_test for the
+// configuration set manually:
+INSTANTIATE_TEST_SUITE_P(manual,
+                         accuracy_test,
+                         ::testing::Values(manual_params),
+                         accuracy_test::TestName);

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -61,7 +61,7 @@ double complex_planar_prob_factor;
 double callback_prob_factor;
 
 // Transform parameters for manual test:
-fft_params manual_params;
+hipfft_params manual_params;
 
 // Host memory limitation for tests (GiB):
 size_t ramgb;
@@ -459,10 +459,7 @@ int main(int argc, char* argv[])
     // suites).
     // set any "unset" parameters of manual_params before initiating gtests
     // (makes the token reported by gtest less ambiguous)
-    if(!*opt_token)
-    {
-        manual_params.validate();
-    }
+    manual_params.validate();
 
     // NB: If we initialize gtest first, then it removes all of its own command-line
     // arguments and sets argc and argv correctly;
@@ -629,5 +626,5 @@ int main(int argc, char* argv[])
 // configuration set manually:
 INSTANTIATE_TEST_SUITE_P(manual,
                          accuracy_test,
-                         ::testing::Values(manual_params),
+                         ::testing::Values(static_cast<const fft_params&>(manual_params)),
                          accuracy_test::TestName);

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -250,18 +250,6 @@ void precompile_test_kernels(const std::string& precompile_file)
               << " ms\n";
 }
 
-// helper function including some testing
-static inline int get_hipfft_version()
-{
-    // TODO: this segfaults, fix in hipFFT and enable here
-    // EXPECT_EQ(hipfftGetVersion(nullptr), HIPFFT_INVALID_VALUE);
-    int v;
-    EXPECT_EQ(hipfftGetVersion(&v), HIPFFT_SUCCESS);
-    // maybe possible to verify v (e.g. by comparison with compile-time-defined
-    // values defined in some backend's header)?
-    return v;
-}
-
 int main(int argc, char* argv[])
 {
     CLI::App app{
@@ -503,10 +491,12 @@ int main(int argc, char* argv[])
         std::cout << app.help() << "\n";
         return EXIT_SUCCESS;
     }
-    const int hipfft_version = get_hipfft_version();
     if(*opt_version || verbose > 0)
     {
+        int hipfft_version;
+        hipfftGetVersion(&hipfft_version);
         std::cout << "hipFFT version: " << hipfft_version << std::endl;
+
         if(*opt_version)
         {
             return EXIT_SUCCESS;

--- a/clients/tests/multi_device_test.cpp
+++ b/clients/tests/multi_device_test.cpp
@@ -33,6 +33,9 @@ static const std::vector<std::vector<size_t>> multi_gpu_sizes = {
     {128, 256},
     {64, 128, 256},
 };
+static const std::vector<size_t>        multi_gpu_batch_range = {10, 1};
+static std::vector<std::vector<size_t>> ioffset_range_zero    = {{0, 0}};
+static std::vector<std::vector<size_t>> ooffset_range_zero    = {{0, 0}};
 
 enum SplitType
 {
@@ -71,22 +74,22 @@ std::vector<fft_params> param_generator_multi_gpu(const std::optional<SplitType>
     auto params_complex                                        = param_generator_complex(test_prob,
                                                   multi_gpu_sizes,
                                                   precision_range_sp_dp,
-                                                  {1, 10},
+                                                  multi_gpu_batch_range,
                                                   stride_generator(stride_range),
                                                   stride_generator(stride_range),
-                                                  {{0, 0}},
-                                                  {{0, 0}},
-                                                  {fft_placement_inplace, fft_placement_notinplace},
+                                                  ioffset_range_zero,
+                                                  ooffset_range_zero,
+                                                  place_range,
                                                   false);
 
     auto params_real = param_generator_real(test_prob,
                                             multi_gpu_sizes,
                                             precision_range_sp_dp,
-                                            {1, 10},
+                                            multi_gpu_batch_range,
                                             stride_generator(stride_range),
                                             stride_generator(stride_range),
-                                            {{0, 0}},
-                                            {{0, 0}},
+                                            ioffset_range_zero,
+                                            ooffset_range_zero,
                                             {fft_placement_notinplace},
                                             false);
 


### PR DESCRIPTION
This PR fixes a few issues for hipfft-test with some additional minor changes:
- some test probability factors are left uninitialized (_e.g._, `real_prob_factor`), possibly resulting in never-triggered tests;
- `random_seed` is never initialized if the `--seed` option is not used;
- there are possible differences between what is tested "manually" or by the parameterized "accuracy_test" suite for one given test token (particularly if `multiGPU > 1`). I'm suggesting to redefine the former as a single-value instance of the latter (requires some shuffling of code blocks so that all the required input parsing is done before the initialization of google tests);
- some variables seem unused despite intended usage (based on the variable names);
- there is a note [here](https://github.com/regan-amd/hipFFT/blob/0b463618d022b04d0ddee493b63c389ed48bc80c/shared/accuracy_test.h#L921) advising to set elements of batch ranges in decreasing order.

Notes
------
- This PR brings some (very little) gains in test coverage (from addressing nonzero probability factors and querying hipfft version in main);
- Input validation seems omitted for `hipfftGetVersion` (that would need fixing).