### PR TITLE
Use same multi-gpu identifier when reading and writing test tokens

### DIFF
--- a/shared/fft_params.h
+++ b/shared/fft_params.h
@@ -1192,7 +1192,7 @@ public:
             ++pos;
         }
 
-        if(pos < vals.size() && vals[pos] == "multiGPU")
+        if(pos < vals.size() && vals[pos] == "multigpu")
         {
             ++pos;
             multiGPU = std::stoull(vals[pos++]);


### PR DESCRIPTION
Equivalent of [PR#600](https://github.com/ROCm/rocFFT/pull/600). Would help unblock some difficulties with multi-gpu test for hipFFT, with [PR#143](https://github.com/ROCm/hipFFT/pull/143).