### PR TITLE
Guarantee test coverage for hipfft's ability to deduce default strides and distances if unset

### DIFF
--- a/clients/hipfft_params.h
+++ b/clients/hipfft_params.h
@@ -32,11 +32,25 @@
 #include "../shared/hipfft_brick.h"
 #include "hipfft/hipfft.h"
 #include "hipfft/hipfftXt.h"
+#include <random>
 
 #ifdef HIPFFT_MPI_ENABLE
 #include "hipfft/hipfftMp.h"
 #include <mpi.h>
 #endif
+
+template <typename T,
+          typename... Args,
+          std::enable_if_t<std::is_integral_v<T> && (std::is_same_v<T, Args> && ...), bool> = true>
+static void set_with_random_nonnegative_values(const std::string& token, T& val, Args&... args)
+{
+    std::hash<std::string>           hasher;
+    std::ranlux24_base               gen(hasher(token));
+    std::uniform_int_distribution<T> dis(static_cast<T>(0), std::numeric_limits<T>::max());
+    val = dis(gen);
+    ((args = dis(gen)), ...);
+    return;
+}
 
 inline fft_status fft_status_from_hipfftparams(const hipfftResult_t val)
 {
@@ -996,24 +1010,35 @@ private:
     }
     hipfftResult_t create_plan_many()
     {
-        auto* inembed = int_inembed.data();
-        auto* onembed = int_onembed.data();
-        if(is_using_default_layout())
+        int*              inembed_arg = int_inembed.data();
+        int*              onembed_arg = int_onembed.data();
+        int               istride_arg = istride.back();
+        int               ostride_arg = ostride.back();
+        int               idist_arg   = idist;
+        int               odist_arg   = odist;
+        const std::string prob_token  = token();
+        if((std::hash<std::string>()(prob_token) % 2) && is_using_default_layout())
         {
             // test hipfft's ability to figure it out
-            inembed = nullptr;
-            onembed = nullptr;
+            inembed_arg = nullptr;
+            onembed_arg = nullptr;
+            // istride, ostride, idist and odist are (should be) effectively ignored if
+            // inembed == nullptr and onembed == nullptr. Use random values for those
+            // arguments to test that behavior.
+            // FIXME: negative values are not truly ignored for now.
+            set_with_random_nonnegative_values(
+                prob_token, istride_arg, ostride_arg, idist_arg, odist_arg);
         }
 
         auto ret = hipfftPlanMany(&plan,
                                   dim(),
                                   int_length.data(),
-                                  inembed,
-                                  istride.back(),
-                                  idist,
-                                  onembed,
-                                  ostride.back(),
-                                  odist,
+                                  inembed_arg,
+                                  istride_arg,
+                                  idist_arg,
+                                  onembed_arg,
+                                  ostride_arg,
+                                  odist_arg,
                                   *hipfft_transform_type,
                                   nbatch);
         return ret;
@@ -1138,24 +1163,35 @@ private:
         if(ret != HIPFFT_SUCCESS)
             return ret;
 
-        auto* inembed = int_inembed.data();
-        auto* onembed = int_onembed.data();
-        if(is_using_default_layout())
+        int*              inembed_arg = int_inembed.data();
+        int*              onembed_arg = int_onembed.data();
+        int               istride_arg = istride.back();
+        int               ostride_arg = ostride.back();
+        int               idist_arg   = idist;
+        int               odist_arg   = odist;
+        const std::string prob_token  = token();
+        if((std::hash<std::string>()(prob_token) % 2) && is_using_default_layout())
         {
             // test hipfft's ability to figure it out
-            inembed = nullptr;
-            onembed = nullptr;
+            inembed_arg = nullptr;
+            onembed_arg = nullptr;
+            // istride, ostride, idist and odist are (should be) effectively ignored if
+            // inembed == nullptr and onembed == nullptr. Use random values for those
+            // arguments to test that behavior.
+            // FIXME: negative values are not truly ignored for now.
+            set_with_random_nonnegative_values(
+                prob_token, istride_arg, ostride_arg, idist_arg, odist_arg);
         }
 
         return hipfftMakePlanMany(plan,
                                   dim(),
                                   int_length.data(),
-                                  inembed,
-                                  istride.back(),
-                                  idist,
-                                  onembed,
-                                  ostride.back(),
-                                  odist,
+                                  inembed_arg,
+                                  istride_arg,
+                                  idist_arg,
+                                  onembed_arg,
+                                  ostride_arg,
+                                  odist_arg,
                                   *hipfft_transform_type,
                                   nbatch,
                                   workbuffersize_ptr);
@@ -1166,23 +1202,34 @@ private:
         auto ret = create_with_pre_make();
         if(ret != HIPFFT_SUCCESS)
             return ret;
-        auto* inembed = ll_inembed.data();
-        auto* onembed = ll_onembed.data();
-        if(is_using_default_layout())
+        long long int*    inembed_arg = ll_inembed.data();
+        long long int*    onembed_arg = ll_onembed.data();
+        long long int     istride_arg = istride.back();
+        long long int     ostride_arg = ostride.back();
+        long long int     idist_arg   = idist;
+        long long int     odist_arg   = odist;
+        const std::string prob_token  = token();
+        if((std::hash<std::string>()(prob_token) % 2) && is_using_default_layout())
         {
             // test hipfft's ability to figure it out
-            inembed = nullptr;
-            onembed = nullptr;
+            inembed_arg = nullptr;
+            onembed_arg = nullptr;
+            // istride, ostride, idist and odist are (should be) effectively ignored if
+            // inembed == nullptr and onembed == nullptr. Use random values for those
+            // arguments to test that behavior.
+            // FIXME: negative values are not truly ignored for now.
+            set_with_random_nonnegative_values(
+                prob_token, istride_arg, ostride_arg, idist_arg, odist_arg);
         }
         return hipfftMakePlanMany64(plan,
                                     dim(),
                                     ll_length.data(),
-                                    inembed,
-                                    istride.back(),
-                                    idist,
-                                    onembed,
-                                    ostride.back(),
-                                    odist,
+                                    inembed_arg,
+                                    istride_arg,
+                                    idist_arg,
+                                    onembed_arg,
+                                    ostride_arg,
+                                    odist_arg,
                                     *hipfft_transform_type,
                                     nbatch,
                                     workbuffersize_ptr);
@@ -1210,26 +1257,36 @@ private:
             executionType = HIP_C_64F;
             break;
         }
-
-        auto* inembed = ll_inembed.data();
-        auto* onembed = ll_onembed.data();
-        if(is_using_default_layout())
+        long long int*    inembed_arg = ll_inembed.data();
+        long long int*    onembed_arg = ll_onembed.data();
+        long long int     istride_arg = istride.back();
+        long long int     ostride_arg = ostride.back();
+        long long int     idist_arg   = idist;
+        long long int     odist_arg   = odist;
+        const std::string prob_token  = token();
+        if((std::hash<std::string>()(prob_token) % 2) && is_using_default_layout())
         {
             // test hipfft's ability to figure it out
-            inembed = nullptr;
-            onembed = nullptr;
+            inembed_arg = nullptr;
+            onembed_arg = nullptr;
+            // istride, ostride, idist and odist are (should be) effectively ignored if
+            // inembed == nullptr and onembed == nullptr. Use random values for those
+            // arguments to test that behavior.
+            // FIXME: negative values are not truly ignored for now.
+            set_with_random_nonnegative_values(
+                prob_token, istride_arg, ostride_arg, idist_arg, odist_arg);
         }
 
         return hipfftXtMakePlanMany(plan,
                                     dim(),
                                     ll_length.data(),
-                                    inembed,
-                                    istride.back(),
-                                    idist,
+                                    inembed_arg,
+                                    istride_arg,
+                                    idist_arg,
                                     inputType,
-                                    onembed,
-                                    ostride.back(),
-                                    odist,
+                                    onembed_arg,
+                                    ostride_arg,
+                                    odist_arg,
                                     outputType,
                                     nbatch,
                                     workbuffersize_ptr,

--- a/clients/hipfft_params.h
+++ b/clients/hipfft_params.h
@@ -30,6 +30,7 @@
 #include "../shared/concurrency.h"
 #include "../shared/fft_params.h"
 #include "../shared/hipfft_brick.h"
+#include "../shared/test_params.h"
 #include "hipfft/hipfft.h"
 #include "hipfft/hipfftXt.h"
 #include <random>
@@ -45,7 +46,7 @@ template <typename T,
 static void set_with_random_nonnegative_values(const std::string& token, T& val, Args&... args)
 {
     std::hash<std::string>           hasher;
-    std::ranlux24_base               gen(hasher(token));
+    std::ranlux24_base               gen(random_seed + hasher(token));
     std::uniform_int_distribution<T> dis(static_cast<T>(0), std::numeric_limits<T>::max());
     val = dis(gen);
     ((args = dis(gen)), ...);
@@ -969,25 +970,32 @@ private:
             ret.input_embed  = ll_inembed.data();
             ret.output_embed = ll_onembed.data();
         }
-        ret.input_stride             = static_cast<T>(istride.back());
-        ret.output_stride            = static_cast<T>(ostride.back());
-        ret.input_distance           = static_cast<T>(idist);
-        ret.output_distance          = static_cast<T>(odist);
-        const std::string test_token = token();
-        if((std::hash<std::string>()(test_token) % 2) && is_using_default_layout())
+        ret.input_stride    = static_cast<T>(istride.back());
+        ret.output_stride   = static_cast<T>(ostride.back());
+        ret.input_distance  = static_cast<T>(idist);
+        ret.output_distance = static_cast<T>(odist);
+        if(is_using_default_layout())
         {
-            // In case of default layouts, the following input arguments are also valid
-            ret.input_embed  = nullptr;
-            ret.output_embed = nullptr;
-            // istride, ostride, idist and odist are (should be) effectively ignored if
-            // inembed == nullptr and onembed == nullptr. Use random values for those
-            // arguments to test that behavior.
-            // FIXME: negative values are not truly ignored for now.
-            set_with_random_nonnegative_values(test_token,
-                                               ret.input_stride,
-                                               ret.output_stride,
-                                               ret.input_distance,
-                                               ret.output_distance);
+            // If using a default layout, users can
+            // (A) either set explicitly inembed, onembed, strides, and distances (like above);
+            // (B) or use nullptr as arguments for inembed and onembed. Strides and
+            //     distances are supposed to be ignored in that case.
+            // --> choose randomly between either valid usage when a default layout is
+            //     used, so that all possible valid use case scenarios are considered.
+            const std::string test_token = token();
+            int               randomizer;
+            set_with_random_nonnegative_values(test_token, randomizer);
+            if(randomizer % 2 == 0)
+            {
+                ret.input_embed  = nullptr;
+                ret.output_embed = nullptr;
+                // FIXME: negative values are not truly ignored for now.
+                set_with_random_nonnegative_values(test_token,
+                                                   ret.input_stride,
+                                                   ret.output_stride,
+                                                   ret.input_distance,
+                                                   ret.output_distance);
+            }
         }
         return ret;
     }

--- a/clients/hipfft_params.h
+++ b/clients/hipfft_params.h
@@ -155,6 +155,13 @@ public:
     std::vector<long long int> ll_inembed;
     std::vector<long long int> ll_onembed;
 
+    template <typename T>
+    struct many_api_layout_args
+    {
+        T *input_embed, *output_embed;
+        T  input_stride, output_stride, input_distance, output_distance;
+    };
+
     struct hipLibXtDesc_deleter
     {
         void operator()(hipLibXtDesc* d)
@@ -946,6 +953,45 @@ private:
         return false;
     }
 
+    template <
+        typename T,
+        std::enable_if_t<std::is_same_v<T, int> || std::is_same_v<T, long long int>, bool> = true>
+    many_api_layout_args<T> make_valid_layout_args_for_plan_many()
+    {
+        many_api_layout_args<T> ret;
+        if constexpr(std::is_same_v<T, int>)
+        {
+            ret.input_embed  = int_inembed.data();
+            ret.output_embed = int_onembed.data();
+        }
+        else
+        {
+            ret.input_embed  = ll_inembed.data();
+            ret.output_embed = ll_onembed.data();
+        }
+        ret.input_stride             = static_cast<T>(istride.back());
+        ret.output_stride            = static_cast<T>(ostride.back());
+        ret.input_distance           = static_cast<T>(idist);
+        ret.output_distance          = static_cast<T>(odist);
+        const std::string test_token = token();
+        if((std::hash<std::string>()(test_token) % 2) && is_using_default_layout())
+        {
+            // In case of default layouts, the following input arguments are also valid
+            ret.input_embed  = nullptr;
+            ret.output_embed = nullptr;
+            // istride, ostride, idist and odist are (should be) effectively ignored if
+            // inembed == nullptr and onembed == nullptr. Use random values for those
+            // arguments to test that behavior.
+            // FIXME: negative values are not truly ignored for now.
+            set_with_random_nonnegative_values(test_token,
+                                               ret.input_stride,
+                                               ret.output_stride,
+                                               ret.input_distance,
+                                               ret.output_distance);
+        }
+        return ret;
+    }
+
     // Not all plan options work with all creation types.  Return a
     // suitable plan creation type for the current FFT parameters.
     int get_create_type()
@@ -1010,35 +1056,16 @@ private:
     }
     hipfftResult_t create_plan_many()
     {
-        int*              inembed_arg = int_inembed.data();
-        int*              onembed_arg = int_onembed.data();
-        int               istride_arg = istride.back();
-        int               ostride_arg = ostride.back();
-        int               idist_arg   = idist;
-        int               odist_arg   = odist;
-        const std::string prob_token  = token();
-        if((std::hash<std::string>()(prob_token) % 2) && is_using_default_layout())
-        {
-            // test hipfft's ability to figure it out
-            inembed_arg = nullptr;
-            onembed_arg = nullptr;
-            // istride, ostride, idist and odist are (should be) effectively ignored if
-            // inembed == nullptr and onembed == nullptr. Use random values for those
-            // arguments to test that behavior.
-            // FIXME: negative values are not truly ignored for now.
-            set_with_random_nonnegative_values(
-                prob_token, istride_arg, ostride_arg, idist_arg, odist_arg);
-        }
-
-        auto ret = hipfftPlanMany(&plan,
+        auto layout_args = make_valid_layout_args_for_plan_many<int>();
+        auto ret         = hipfftPlanMany(&plan,
                                   dim(),
                                   int_length.data(),
-                                  inembed_arg,
-                                  istride_arg,
-                                  idist_arg,
-                                  onembed_arg,
-                                  ostride_arg,
-                                  odist_arg,
+                                  layout_args.input_embed,
+                                  layout_args.input_stride,
+                                  layout_args.input_distance,
+                                  layout_args.output_embed,
+                                  layout_args.output_stride,
+                                  layout_args.output_distance,
                                   *hipfft_transform_type,
                                   nbatch);
         return ret;
@@ -1162,36 +1189,16 @@ private:
         auto ret = create_with_pre_make();
         if(ret != HIPFFT_SUCCESS)
             return ret;
-
-        int*              inembed_arg = int_inembed.data();
-        int*              onembed_arg = int_onembed.data();
-        int               istride_arg = istride.back();
-        int               ostride_arg = ostride.back();
-        int               idist_arg   = idist;
-        int               odist_arg   = odist;
-        const std::string prob_token  = token();
-        if((std::hash<std::string>()(prob_token) % 2) && is_using_default_layout())
-        {
-            // test hipfft's ability to figure it out
-            inembed_arg = nullptr;
-            onembed_arg = nullptr;
-            // istride, ostride, idist and odist are (should be) effectively ignored if
-            // inembed == nullptr and onembed == nullptr. Use random values for those
-            // arguments to test that behavior.
-            // FIXME: negative values are not truly ignored for now.
-            set_with_random_nonnegative_values(
-                prob_token, istride_arg, ostride_arg, idist_arg, odist_arg);
-        }
-
+        auto layout_args = make_valid_layout_args_for_plan_many<int>();
         return hipfftMakePlanMany(plan,
                                   dim(),
                                   int_length.data(),
-                                  inembed_arg,
-                                  istride_arg,
-                                  idist_arg,
-                                  onembed_arg,
-                                  ostride_arg,
-                                  odist_arg,
+                                  layout_args.input_embed,
+                                  layout_args.input_stride,
+                                  layout_args.input_distance,
+                                  layout_args.output_embed,
+                                  layout_args.output_stride,
+                                  layout_args.output_distance,
                                   *hipfft_transform_type,
                                   nbatch,
                                   workbuffersize_ptr);
@@ -1202,34 +1209,16 @@ private:
         auto ret = create_with_pre_make();
         if(ret != HIPFFT_SUCCESS)
             return ret;
-        long long int*    inembed_arg = ll_inembed.data();
-        long long int*    onembed_arg = ll_onembed.data();
-        long long int     istride_arg = istride.back();
-        long long int     ostride_arg = ostride.back();
-        long long int     idist_arg   = idist;
-        long long int     odist_arg   = odist;
-        const std::string prob_token  = token();
-        if((std::hash<std::string>()(prob_token) % 2) && is_using_default_layout())
-        {
-            // test hipfft's ability to figure it out
-            inembed_arg = nullptr;
-            onembed_arg = nullptr;
-            // istride, ostride, idist and odist are (should be) effectively ignored if
-            // inembed == nullptr and onembed == nullptr. Use random values for those
-            // arguments to test that behavior.
-            // FIXME: negative values are not truly ignored for now.
-            set_with_random_nonnegative_values(
-                prob_token, istride_arg, ostride_arg, idist_arg, odist_arg);
-        }
+        auto layout_args = make_valid_layout_args_for_plan_many<long long int>();
         return hipfftMakePlanMany64(plan,
                                     dim(),
                                     ll_length.data(),
-                                    inembed_arg,
-                                    istride_arg,
-                                    idist_arg,
-                                    onembed_arg,
-                                    ostride_arg,
-                                    odist_arg,
+                                    layout_args.input_embed,
+                                    layout_args.input_stride,
+                                    layout_args.input_distance,
+                                    layout_args.output_embed,
+                                    layout_args.output_stride,
+                                    layout_args.output_distance,
                                     *hipfft_transform_type,
                                     nbatch,
                                     workbuffersize_ptr);
@@ -1257,36 +1246,18 @@ private:
             executionType = HIP_C_64F;
             break;
         }
-        long long int*    inembed_arg = ll_inembed.data();
-        long long int*    onembed_arg = ll_onembed.data();
-        long long int     istride_arg = istride.back();
-        long long int     ostride_arg = ostride.back();
-        long long int     idist_arg   = idist;
-        long long int     odist_arg   = odist;
-        const std::string prob_token  = token();
-        if((std::hash<std::string>()(prob_token) % 2) && is_using_default_layout())
-        {
-            // test hipfft's ability to figure it out
-            inembed_arg = nullptr;
-            onembed_arg = nullptr;
-            // istride, ostride, idist and odist are (should be) effectively ignored if
-            // inembed == nullptr and onembed == nullptr. Use random values for those
-            // arguments to test that behavior.
-            // FIXME: negative values are not truly ignored for now.
-            set_with_random_nonnegative_values(
-                prob_token, istride_arg, ostride_arg, idist_arg, odist_arg);
-        }
 
+        auto layout_args = make_valid_layout_args_for_plan_many<long long int>();
         return hipfftXtMakePlanMany(plan,
                                     dim(),
                                     ll_length.data(),
-                                    inembed_arg,
-                                    istride_arg,
-                                    idist_arg,
+                                    layout_args.input_embed,
+                                    layout_args.input_stride,
+                                    layout_args.input_distance,
                                     inputType,
-                                    onembed_arg,
-                                    ostride_arg,
-                                    odist_arg,
+                                    layout_args.output_embed,
+                                    layout_args.output_stride,
+                                    layout_args.output_distance,
                                     outputType,
                                     nbatch,
                                     workbuffersize_ptr,

--- a/clients/hipfft_params.h
+++ b/clients/hipfft_params.h
@@ -996,13 +996,22 @@ private:
     }
     hipfftResult_t create_plan_many()
     {
+        auto* inembed = int_inembed.data();
+        auto* onembed = int_onembed.data();
+        if(is_using_default_layout())
+        {
+            // test hipfft's ability to figure it out
+            inembed = nullptr;
+            onembed = nullptr;
+        }
+
         auto ret = hipfftPlanMany(&plan,
                                   dim(),
                                   int_length.data(),
-                                  int_inembed.data(),
+                                  inembed,
                                   istride.back(),
                                   idist,
-                                  int_onembed.data(),
+                                  onembed,
                                   ostride.back(),
                                   odist,
                                   *hipfft_transform_type,
@@ -1128,13 +1137,23 @@ private:
         auto ret = create_with_pre_make();
         if(ret != HIPFFT_SUCCESS)
             return ret;
+
+        auto* inembed = int_inembed.data();
+        auto* onembed = int_onembed.data();
+        if(is_using_default_layout())
+        {
+            // test hipfft's ability to figure it out
+            inembed = nullptr;
+            onembed = nullptr;
+        }
+
         return hipfftMakePlanMany(plan,
                                   dim(),
                                   int_length.data(),
-                                  int_inembed.data(),
+                                  inembed,
                                   istride.back(),
                                   idist,
-                                  int_onembed.data(),
+                                  onembed,
                                   ostride.back(),
                                   odist,
                                   *hipfft_transform_type,
@@ -1147,13 +1166,21 @@ private:
         auto ret = create_with_pre_make();
         if(ret != HIPFFT_SUCCESS)
             return ret;
+        auto* inembed = ll_inembed.data();
+        auto* onembed = ll_onembed.data();
+        if(is_using_default_layout())
+        {
+            // test hipfft's ability to figure it out
+            inembed = nullptr;
+            onembed = nullptr;
+        }
         return hipfftMakePlanMany64(plan,
                                     dim(),
                                     ll_length.data(),
-                                    ll_inembed.data(),
+                                    inembed,
                                     istride.back(),
                                     idist,
-                                    ll_onembed.data(),
+                                    onembed,
                                     ostride.back(),
                                     odist,
                                     *hipfft_transform_type,
@@ -1184,14 +1211,23 @@ private:
             break;
         }
 
+        auto* inembed = ll_inembed.data();
+        auto* onembed = ll_onembed.data();
+        if(is_using_default_layout())
+        {
+            // test hipfft's ability to figure it out
+            inembed = nullptr;
+            onembed = nullptr;
+        }
+
         return hipfftXtMakePlanMany(plan,
                                     dim(),
                                     ll_length.data(),
-                                    ll_inembed.data(),
+                                    inembed,
                                     istride.back(),
                                     idist,
                                     inputType,
-                                    ll_onembed.data(),
+                                    onembed,
                                     ostride.back(),
                                     odist,
                                     outputType,

--- a/shared/fft_params.h
+++ b/shared/fft_params.h
@@ -1853,6 +1853,56 @@ public:
     {
         return run_callbacks;
     }
+    // checks if the parameters are consistent with a "default" data layout (considering strides and distances)
+    bool is_using_default_layout() const
+    {
+        auto is_zero                = [](const decltype(ioffset)::value_type& i) { return i == 0; };
+        bool default_layout_is_used = std::all_of(ioffset.begin(), ioffset.end(), is_zero)
+                                      && std::all_of(ooffset.begin(), ooffset.end(), is_zero);
+        size_t default_ival = 1;
+        size_t default_oval = 1;
+        default_layout_is_used
+            &= (default_ival == istride.back()) && (default_oval == ostride.back());
+        switch(transform_type)
+        {
+        case fft_transform_type_complex_forward:
+        case fft_transform_type_complex_inverse:
+        {
+            default_ival *= length.back();
+            default_oval *= length.back();
+            break;
+        }
+        case fft_transform_type_real_forward:
+        case fft_transform_type_real_inverse:
+        {
+            const size_t hermitian_symmetric_length = length.back() / 2 + 1;
+            size_t*      ptr_default_real_val       = &default_ival;
+            size_t*      ptr_default_cmplx_val      = &default_oval;
+            if(transform_type == fft_transform_type_real_inverse)
+                std::swap(ptr_default_real_val, ptr_default_cmplx_val);
+            *ptr_default_cmplx_val *= hermitian_symmetric_length;
+            if(placement == fft_placement_inplace)
+                *ptr_default_real_val *= 2 * hermitian_symmetric_length; // padding to be used
+            else
+                *ptr_default_real_val *= length.back();
+            break;
+        }
+        default:
+            throw std::runtime_error("Invalid transform type");
+        }
+        // check strides for multi-dimensional cases
+        for(int stride_idx = static_cast<int>(dim()) - 2; stride_idx >= 0 && default_layout_is_used;
+            stride_idx--)
+        {
+            default_layout_is_used
+                &= (default_ival == istride[stride_idx]) && (default_oval == ostride[stride_idx]);
+            default_ival *= length[stride_idx];
+            default_oval *= length[stride_idx];
+        }
+        // check distances
+        default_layout_is_used &= (idist == default_ival) && (odist == default_oval);
+        return default_layout_is_used;
+    }
 
     // Given a data type and dimensions, fill the buffer, imposing Hermitian symmetry if necessary.
     template <typename Tbuff>


### PR DESCRIPTION
Changes suggested to improve coverage for hipfft's [code branch](https://github.com/ROCm/hipFFT/blob/3ae1e37759ab78829b17080d519f4c0933f2502c/library/src/amd_detail/hipfft.cpp#L486) taken if `re_calc_strides_in_desc == true`.

Observed impact on coverage reports: about +10% in line coverage, +7% in region coverage and branch coverage for [library/src/amd_detail/hipfft.cpp](https://github.com/ROCm/hipFFT/blob/develop/library/src/amd_detail/hipfft.cpp) (main unit contributing to the report).