### PR TITLE
Remove unnecessary includes

### DIFF
--- a/library/src/amd_detail/hipfft.cpp
+++ b/library/src/amd_detail/hipfft.cpp
@@ -32,8 +32,6 @@
 #include "hipfft/hipfftMp.h"
 #endif
 
-#include "../../../shared/arithmetic.h"
-#include "../../../shared/gpubuf.h"
 #include "../../../shared/ptrdiff.h"
 #include "../../../shared/rocfft_hip.h"
 


### PR DESCRIPTION
These includes seem unjustified, hence the suggestion.

Note: the content of `shared/arithmetic.h` adds to the missed regions of the code coverage reports, thereby artificially lowering the metrics (if truly unnecessary, as suspected).