### PR TITLE
Making singleton host_memory struct thread-safe

### DIFF
--- a/shared/sys_mem.h
+++ b/shared/sys_mem.h
@@ -106,7 +106,7 @@ private:
     host_memory()
     {
         update();
-        // Note: passing (reading) a member varaible as argument to a member routine that
+        // Note: passing (reading) a member variable as argument to a member routine that
         // requires a unique lock. This constructor is only possibly invoked at initialization
         // of the local static variable in the "singleton" public member function though, and
         // that initialization is guaranteed to be thread-safe in C++11.

--- a/shared/sys_mem.h
+++ b/shared/sys_mem.h
@@ -23,6 +23,8 @@
 
 #include <fstream>
 #include <memory>
+#include <mutex>
+#include <shared_mutex>
 
 #include "device_properties.h"
 
@@ -49,18 +51,20 @@ public:
         return mem;
     }
 
-    size_t get_total_bytes()
+    size_t get_total_bytes() const
     {
+        std::shared_lock lock(host_memory_mutex);
         return total_bytes;
     }
 
-    size_t get_total_gbytes()
+    size_t get_total_gbytes() const
     {
         return bytes_to_GiB(get_total_bytes());
     }
 
     void set_limit_bytes(size_t limit_bytes_)
     {
+        std::unique_lock lock(host_memory_mutex);
         // Don't let limit use the total available memory, leave at
         // least a 1GiB buffer, otherwise process may get OOM killed.
         limit_bytes
@@ -79,6 +83,8 @@ public:
         // Limit the amount of usable memory. If we are too aggressive
         // with host memory usage, the host process may get OOM killed
         // on systems with little or no swap space.
+        std::shared_lock lock(host_memory_mutex);
+
         auto usable_bytes = free_bytes < ONE_GiB ? 0 : free_bytes;
         usable_bytes      = usable_bytes > limit_bytes ? limit_bytes : usable_bytes;
 
@@ -95,14 +101,21 @@ private:
     size_t free_bytes  = 0;
     size_t limit_bytes = 0;
 
+    mutable std::shared_mutex host_memory_mutex;
+
     host_memory()
     {
         update();
+        // Note: passing (reading) a member varaible as argument to a member routine that
+        // requires a unique lock. This constructor is only possibly invoked at initialization
+        // of the local static variable in the "singleton" public member function though, and
+        // that initialization is guaranteed to be thread-safe in C++11.
         set_limit_bytes(total_bytes);
     }
 
     void update()
     {
+        std::unique_lock lock(host_memory_mutex);
 #ifdef WIN32
         MEMORYSTATUSEX info;
         info.dwLength = sizeof(info);


### PR DESCRIPTION
The zero-initialization steps of member variables within the singleton `host_memory` structure's `update` member function (steps added in [PR#152](https://github.com/ROCm/hipFFT/pull/152)) exposed possible race conditions in hipfft-test's accuracy tests. These changes are suggested to improve `host_memory`'s thread safety.

The `host_memory`'s `update` member function can be called simultaneously by separate threads in `fft_vs_reference_impl`:
- one time as a result of [this operation](https://github.com/ROCm/hipFFT/blob/a2e81be5a21eee22d43a1ce379c7f0db0ab575c2/shared/accuracy_test.h#L1310) (executed by the main thread);
- another time as a result of [that operation](https://github.com/ROCm/hipFFT/blob/a2e81be5a21eee22d43a1ce379c7f0db0ab575c2/shared/accuracy_test.h#L1279) (possibly launched in a separate thread).

This race condition triggers random tests to be sporadically (and non-reproducibly) skipped more frequently since [PR#152](https://github.com/ROCm/hipFFT/pull/152), because it may trigger [this exception](https://github.com/ROCm/hipFFT/blob/a2e81be5a21eee22d43a1ce379c7f0db0ab575c2/shared/hostbuf.h#L95) to be thrown rather randomly.

[EDIT]: will open similar changes for the rocfft repo once/if approved and merged here.