### PR TITLE
Increase smoketest's test probability, force usage of multi-gpu and callback features when generating a code coverage report

### DIFF
--- a/clients/hipfft_params.h
+++ b/clients/hipfft_params.h
@@ -454,10 +454,12 @@ public:
         }
     }
 
-    fft_status set_callbacks(void* load_cb_host,
-                             void* load_cb_data,
-                             void* store_cb_host,
-                             void* store_cb_data) override
+    fft_status set_callbacks(void*  load_cb_host,
+                             void*  load_cb_data,
+                             void*  store_cb_host,
+                             void*  store_cb_data,
+                             size_t load_cb_shared_mem_bytes  = 0,
+                             size_t store_cb_shared_mem_bytes = 0) override
     {
         if(run_callbacks)
         {
@@ -476,6 +478,16 @@ public:
                     plan, &store_cb_host, HIPFFT_CB_ST_COMPLEX, &store_cb_data);
                 if(ret != HIPFFT_SUCCESS)
                     return fft_status_from_hipfftparams(ret);
+
+                ret = hipfftXtSetCallbackSharedSize(
+                    plan, HIPFFT_CB_LD_REAL, load_cb_shared_mem_bytes);
+                if(ret != HIPFFT_SUCCESS)
+                    return fft_status_from_hipfftparams(ret);
+
+                ret = hipfftXtSetCallbackSharedSize(
+                    plan, HIPFFT_CB_ST_COMPLEX, store_cb_shared_mem_bytes);
+                if(ret != HIPFFT_SUCCESS)
+                    return fft_status_from_hipfftparams(ret);
                 break;
             case HIPFFT_D2Z:
                 ret = hipfftXtSetCallback(
@@ -487,6 +499,16 @@ public:
                     plan, &store_cb_host, HIPFFT_CB_ST_COMPLEX_DOUBLE, &store_cb_data);
                 if(ret != HIPFFT_SUCCESS)
                     return fft_status_from_hipfftparams(ret);
+
+                ret = hipfftXtSetCallbackSharedSize(
+                    plan, HIPFFT_CB_LD_REAL_DOUBLE, load_cb_shared_mem_bytes);
+                if(ret != HIPFFT_SUCCESS)
+                    return fft_status_from_hipfftparams(ret);
+
+                ret = hipfftXtSetCallbackSharedSize(
+                    plan, HIPFFT_CB_ST_COMPLEX_DOUBLE, store_cb_shared_mem_bytes);
+                if(ret != HIPFFT_SUCCESS)
+                    return fft_status_from_hipfftparams(ret);
                 break;
             case HIPFFT_C2R:
                 ret = hipfftXtSetCallback(plan, &load_cb_host, HIPFFT_CB_LD_COMPLEX, &load_cb_data);
@@ -494,6 +516,16 @@ public:
                     return fft_status_from_hipfftparams(ret);
 
                 ret = hipfftXtSetCallback(plan, &store_cb_host, HIPFFT_CB_ST_REAL, &store_cb_data);
+                if(ret != HIPFFT_SUCCESS)
+                    return fft_status_from_hipfftparams(ret);
+
+                ret = hipfftXtSetCallbackSharedSize(
+                    plan, HIPFFT_CB_LD_COMPLEX, load_cb_shared_mem_bytes);
+                if(ret != HIPFFT_SUCCESS)
+                    return fft_status_from_hipfftparams(ret);
+
+                ret = hipfftXtSetCallbackSharedSize(
+                    plan, HIPFFT_CB_ST_REAL, store_cb_shared_mem_bytes);
                 if(ret != HIPFFT_SUCCESS)
                     return fft_status_from_hipfftparams(ret);
                 break;
@@ -507,6 +539,16 @@ public:
                     plan, &store_cb_host, HIPFFT_CB_ST_REAL_DOUBLE, &store_cb_data);
                 if(ret != HIPFFT_SUCCESS)
                     return fft_status_from_hipfftparams(ret);
+
+                ret = hipfftXtSetCallbackSharedSize(
+                    plan, HIPFFT_CB_LD_COMPLEX_DOUBLE, load_cb_shared_mem_bytes);
+                if(ret != HIPFFT_SUCCESS)
+                    return fft_status_from_hipfftparams(ret);
+
+                ret = hipfftXtSetCallbackSharedSize(
+                    plan, HIPFFT_CB_ST_REAL_DOUBLE, store_cb_shared_mem_bytes);
+                if(ret != HIPFFT_SUCCESS)
+                    return fft_status_from_hipfftparams(ret);
                 break;
             case HIPFFT_C2C:
                 ret = hipfftXtSetCallback(plan, &load_cb_host, HIPFFT_CB_LD_COMPLEX, &load_cb_data);
@@ -515,6 +557,16 @@ public:
 
                 ret = hipfftXtSetCallback(
                     plan, &store_cb_host, HIPFFT_CB_ST_COMPLEX, &store_cb_data);
+                if(ret != HIPFFT_SUCCESS)
+                    return fft_status_from_hipfftparams(ret);
+
+                ret = hipfftXtSetCallbackSharedSize(
+                    plan, HIPFFT_CB_LD_COMPLEX, load_cb_shared_mem_bytes);
+                if(ret != HIPFFT_SUCCESS)
+                    return fft_status_from_hipfftparams(ret);
+
+                ret = hipfftXtSetCallbackSharedSize(
+                    plan, HIPFFT_CB_ST_COMPLEX, store_cb_shared_mem_bytes);
                 if(ret != HIPFFT_SUCCESS)
                     return fft_status_from_hipfftparams(ret);
                 break;
@@ -526,6 +578,16 @@ public:
 
                 ret = hipfftXtSetCallback(
                     plan, &store_cb_host, HIPFFT_CB_ST_COMPLEX_DOUBLE, &store_cb_data);
+                if(ret != HIPFFT_SUCCESS)
+                    return fft_status_from_hipfftparams(ret);
+
+                ret = hipfftXtSetCallbackSharedSize(
+                    plan, HIPFFT_CB_LD_COMPLEX_DOUBLE, load_cb_shared_mem_bytes);
+                if(ret != HIPFFT_SUCCESS)
+                    return fft_status_from_hipfftparams(ret);
+
+                ret = hipfftXtSetCallbackSharedSize(
+                    plan, HIPFFT_CB_ST_COMPLEX_DOUBLE, store_cb_shared_mem_bytes);
                 if(ret != HIPFFT_SUCCESS)
                     return fft_status_from_hipfftparams(ret);
                 break;

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -224,7 +224,7 @@ if (WIN32)
 endif()
 
 option(BUILD_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
-set(COVERAGE_TEST_OPTIONS "--smoketest" CACHE STRING "Command line arguments for hipfft-test when generating a code coverage report")
+set(COVERAGE_TEST_OPTIONS "--smoketest" CACHE STRING "Command line arguments for hipfft-test when generating a code coverage report (Note: an additional run of hipfft-test targeting multi_gpu* and callback* tests is always executed and coverage results are aggregated)")
 if (BUILD_CODE_COVERAGE)
   add_custom_target(
     code_cov_tests
@@ -232,6 +232,7 @@ if (BUILD_CODE_COVERAGE)
     COMMAND ${CMAKE_COMMAND} -E rm -rf ./coverage-report
     COMMAND ${CMAKE_COMMAND} -E make_directory ./coverage-report/profraw
     COMMAND ${CMAKE_COMMAND} -E env LLVM_PROFILE_FILE="./coverage-report/profraw/hipfft-coverage_%p.profraw" GTEST_LISTENER=NO_PASS_LINE_IN_LOG $<TARGET_FILE:hipfft-test> --precompile=./clients/staging/hipfft-test-precompile.db ${COVERAGE_TEST_OPTIONS}
+    COMMAND ${CMAKE_COMMAND} -E env LLVM_PROFILE_FILE="./coverage-report/profraw/hipfft-coverage_%p.profraw" GTEST_LISTENER=NO_PASS_LINE_IN_LOG $<TARGET_FILE:hipfft-test> --precompile=./clients/staging/hipfft-test-precompile-multi_gpu-plus-callback.db --gtest_filter=multi_gpu*:callback*
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -319,7 +319,7 @@ int main(int argc, char* argv[])
         ->each([&](const std::string&) {
             // The objective is to have an test that takes about 5 minutes, so just set the probability
             // per test to a small value to achieve this result.
-            test_prob = 0.002;
+            test_prob = 0.02;
         });
 
     // Try parsing initial args that will be used to configure tests

--- a/shared/fft_params.h
+++ b/shared/fft_params.h
@@ -2160,10 +2160,12 @@ public:
         }
     }
 
-    virtual fft_status set_callbacks(void* load_cb_host,
-                                     void* load_cb_data,
-                                     void* store_cb_host,
-                                     void* store_cb_data)
+    virtual fft_status set_callbacks(void*  load_cb_host,
+                                     void*  load_cb_data,
+                                     void*  store_cb_host,
+                                     void*  store_cb_data,
+                                     size_t load_cb_shared_mem_bytes,
+                                     size_t store_cb_shared_mem_bytes)
     {
         return fft_status_success;
     }

--- a/shared/rocfft_params.h
+++ b/shared/rocfft_params.h
@@ -443,20 +443,22 @@ public:
         return ret;
     }
 
-    fft_status set_callbacks(void* load_cb_host,
-                             void* load_cb_data,
-                             void* store_cb_host,
-                             void* store_cb_data) override
+    fft_status set_callbacks(void*  load_cb_host,
+                             void*  load_cb_data,
+                             void*  store_cb_host,
+                             void*  store_cb_data,
+                             size_t load_cb_shared_mem_bytes  = 0,
+                             size_t store_cb_shared_mem_bytes = 0) override
     {
         if(run_callbacks)
         {
-            auto roc_status
-                = rocfft.execution_info_set_load_callback(info, &load_cb_host, &load_cb_data, 0);
+            auto roc_status = rocfft.execution_info_set_load_callback(
+                info, &load_cb_host, &load_cb_data, load_cb_shared_mem_bytes);
             if(roc_status != rocfft_status_success)
                 return fft_status_from_rocfftparams(roc_status);
 
-            roc_status
-                = rocfft.execution_info_set_store_callback(info, &store_cb_host, &store_cb_data, 0);
+            roc_status = rocfft.execution_info_set_store_callback(
+                info, &store_cb_host, &store_cb_data, store_cb_shared_mem_bytes);
             if(roc_status != rocfft_status_success)
                 return fft_status_from_rocfftparams(roc_status);
         }


### PR DESCRIPTION
Details and motivations for the changes:
==========================
- f5eecc292a5db9cd0b545420e27a154bda0591ae forces an additional run of `hipfft-test` using option `--gtest_filter=multi_gpu*:callback*` when generating a code coverage report. The low default value set for `callback_prob_factor` and the small overall number of `multi_gpu` tests make it likely to miss testing for both of these categories when generating a coverage report, otherwise;
- 16b646590c644f9523e89d211e38fcf34cbd125e increases the overall test probability used with the `--smoketest` option, making it much less likely to miss testing for some features that are already covered in the many instances of `accuracy_test` (_e.g._, usage of scaling factors). Test times are still below 5 minutes with that option, in my experience (gfx1201);
- d0cbcba2dd4b45fae4a9dc68098dab6deb799daf expands the `fft_params` class and its inherited classes to (conceptually) set nonzero shared memory when configuring their instances with callbacks. Current usage is restricted to default values (_i.e._, `0`) in tests but that simple addition may be required in the future anyways (once/if nonzero shared memory sizes need to be enabled and/or considered throughout). This change improves code coverage report for hipFFT by leveraging a generalized usage of the `hipfftXtSetCallbackSharedSize` function via the `callback*` accuracy tests.

The changes to `shared` will be applied in the rocfft repo if relevant and if/when this is approved and merged.