### PR TITLE
Enable round-trips in multi-gpu accuracy tests

### DIFF
--- a/clients/tests/hipfft_accuracy_test.cpp
+++ b/clients/tests/hipfft_accuracy_test.cpp
@@ -78,12 +78,12 @@ TEST_P(accuracy_test, vs_fftw)
     {
     case fft_params::fft_mp_lib_none:
     {
-        // only do round trip for single-GPU FFTs
-        bool round_trip = params.multiGPU <= 1;
+        // only do round trip for forward FFTs
+        const bool do_round_trip = params.is_forward();
 
         try
         {
-            fft_vs_reference(params, round_trip);
+            fft_vs_reference(params, do_round_trip);
         }
         catch(HOSTBUF_MEM_USAGE& e)
         {

--- a/clients/tests/multi_device_test.cpp
+++ b/clients/tests/multi_device_test.cpp
@@ -31,7 +31,9 @@ extern int                    mp_ranks;
 
 static const std::vector<std::vector<size_t>> multi_gpu_sizes = {
     {128, 256},
+    {192, 768},
     {64, 128, 256},
+    {96, 160, 192},
 };
 static const std::vector<size_t>        multi_gpu_batch_range = {10, 1};
 static std::vector<std::vector<size_t>> ioffset_range_zero    = {{0, 0}};

--- a/shared/accuracy_test.h
+++ b/shared/accuracy_test.h
@@ -352,7 +352,7 @@ inline void execute_gpu_fft(Tparams&              params,
     // Execute the transform:
     auto fft_status = params.execute(pibuffer.data(), pobuffer.data());
     if(fft_status != fft_status_success)
-        throw std::runtime_error("rocFFT plan execution failure");
+        throw std::runtime_error("plan execution failure");
     // work around potential problem of following hipMemcpy
     // not properly waiting for rocFFT's kernels to finish
     if(hipDeviceSynchronize() != hipSuccess)
@@ -547,6 +547,7 @@ void check_output_strides(const std::vector<hostbuf>& output, Tparams& params)
 // run rocFFT inverse transform
 template <class Tparams>
 inline void run_round_trip_inverse(Tparams&              params,
+                                   std::vector<gpubuf>&  ibuffer,
                                    std::vector<gpubuf>&  obuffer,
                                    std::vector<void*>&   pibuffer,
                                    std::vector<void*>&   pobuffer,
@@ -611,7 +612,14 @@ inline void run_round_trip_inverse(Tparams&              params,
             }
         }
     }
-
+    if(params.multiGPU > 1)
+    {
+        if(verbose > 0)
+        {
+            std::cout << "scattering data for multi-GPU inverse" << std::endl;
+        }
+        params.multi_gpu_prepare(ibuffer, pibuffer, pobuffer);
+    }
     // execute GPU transform
     execute_gpu_fft(params, pibuffer, pobuffer, obuffer, gpu_output, true);
 }
@@ -1405,7 +1413,7 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
         params_inverse.inverse_from_forward(params);
 
         run_round_trip_inverse<Tparams>(
-            params_inverse, ibuffer, pobuffer, pibuffer, gpu_input_data);
+            params_inverse, *obuffer, ibuffer, pobuffer, pibuffer, gpu_input_data);
     }
 
     if(fftw_compare)

--- a/shared/fft_params.h
+++ b/shared/fft_params.h
@@ -774,6 +774,17 @@ public:
         }
     }
 
+    bool is_inverse() const
+    {
+        return transform_type == fft_transform_type_complex_inverse
+               || transform_type == fft_transform_type_real_inverse;
+    }
+
+    bool is_forward() const
+    {
+        return !is_inverse();
+    }
+
     // Convert to string for output.
     std::string str(const std::string& separator = ", ") const
     {
@@ -2234,6 +2245,7 @@ public:
         ooffset   = params_forward.ioffset;
 
         run_callbacks = params_forward.run_callbacks;
+        multiGPU      = params_forward.multiGPU;
 
         check_output_strides = params_forward.check_output_strides;
 


### PR DESCRIPTION
These changes are suggested to enable round-trip operations in multi-gpu accuracy tests, the motivation being to indirectly cover inverse multi-gpu usage in the accuracy tests (required to cover usage of `hipfftXtExecDescriptorC2R` and `hipfftXtExecDescriptorZ2D`).