### PR TITLE
Prevent double allocation and memory leak in hipfft test

### DIFF
--- a/clients/tests/simple_test.cpp
+++ b/clients/tests/simple_test.cpp
@@ -50,9 +50,8 @@ inline double type_epsilon_simple<double>()
 
 TEST(hipfftTest, Create1dPlan)
 {
-    hipfftHandle plan = hipfft_params::INVALID_PLAN_HANDLE;
-    ASSERT_EQ(hipfftCreate(&plan), HIPFFT_SUCCESS);
-    size_t length = 1024;
+    hipfftHandle plan   = nullptr;
+    size_t       length = 1024;
     ASSERT_EQ(hipfftPlan1d(&plan, length, HIPFFT_C2C, 1), HIPFFT_SUCCESS);
 
     ASSERT_EQ(hipfftDestroy(plan), HIPFFT_SUCCESS);


### PR DESCRIPTION
resolves #9196

Summary of proposed changes:
-  The following command was giving memory leaks on several systems:
`valgrind --leak-check=full ./hipfft-test --gtest_filter=hipfftTest.Create1dPlan`

.../hipFFT/build/clients/staging/hipfft-test)==3449113====3449113== LEAK SUMMARY:==3449113==    definitely lost: 312 bytes in 1 blocks==3449113==    indirectly lost: 72 bytes in 1 blocks==3449113==      possibly lost: 304 bytes in 2 blocks==3449113==    still reachable: 646,103 bytes in 6,352 blocks==3449113==         suppressed: 0 bytes in 0 blocks==3449113== Reachable blocks (those to which a pointer was found) are not shown.==3449113== To see them, rerun with: --leak-check=full --show-leak-kinds=all

-  Upon debugging, we noticed a potential leak in `hipfftPlan1d` due to redundant `hipfftCreate`.
-  Updating accordingly has resolved the leaks
