### PR TITLE
Avoid aborted tests due to precision mismatch in cache

### DIFF
--- a/shared/accuracy_test.h
+++ b/shared/accuracy_test.h
@@ -851,7 +851,8 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
     if(fftw_compare && last_cpu_fft_data.length == params.length
        && last_cpu_fft_data.transform_type == params.transform_type
        && last_cpu_fft_data.run_callbacks == params.run_callbacks
-       && last_cpu_fft_data.scale_factor == params.scale_factor)
+       && last_cpu_fft_data.scale_factor == params.scale_factor
+       && last_cpu_fft_data.precision >= params.precision)
     {
         if(last_cpu_fft_data.nbatch >= params.nbatch)
         {


### PR DESCRIPTION
Change suggested to avoid running into subsequent `abort`(s).

It's possible to create cached CPU data that would make the/any test abort (by using a manual test token of lesser precision than the first accuracy test to be done thereafter).